### PR TITLE
Add CI workflow for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Core tests (vitest)
+        run: bun run --cwd packages/core test
+
+      - name: CLI tests
+        run: bun run --cwd packages/cli test
+
+      - name: Generator tests
+        run: bun run --cwd apps/generator test
+
+      - name: Desktop tests
+        run: bun run --cwd apps/desktop test


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that runs all unit tests on push to main and on PRs
- Runs core (vitest), CLI, generator, and desktop test suites separately for clear failure reporting

## Test plan
- [ ] Verify the workflow runs and all 190 tests pass in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a CI workflow that runs existing test commands; low risk aside from potential CI flakiness or environment-specific failures (Bun/latest).
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/test.yml`) that runs on pushes and PRs to `main`.
> 
> The job sets up Bun, installs dependencies with `--frozen-lockfile`, and executes the `core`, `cli`, `generator`, and `desktop` test suites as separate steps for clearer failure reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be5d330261db06bc27109b6f0b931488cb336c0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->