### PR TITLE
fix(erc7730): remove permissive .passthrough() from parser schemas

### DIFF
--- a/packages/core/src/lib/erc7730/parser.ts
+++ b/packages/core/src/lib/erc7730/parser.ts
@@ -29,12 +29,11 @@ const MetadataSchema = z.object({
       deploymentDate: z.string().optional(),
       url: z.string().optional(),
     })
-    .passthrough()
     .optional(),
   token: TokenMetadataSchema.optional(),
   constants: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
   enums: z.record(z.record(z.string())).optional(),
-}).passthrough();
+});
 
 const FieldFormatSchema = z.enum([
   "raw",
@@ -60,18 +59,18 @@ const FieldDefinitionSchema: z.ZodType<any> = z.lazy(() =>
     params: z.record(z.unknown()).optional().nullable(),
     fields: z.array(z.unknown()).optional(),
     value: z.unknown().optional(),
-  }).passthrough()
+  })
 );
 
 const FormatEntrySchema = z.object({
   intent: z.string().optional(),
   fields: z.array(FieldDefinitionSchema),
-}).passthrough();
+});
 
 const DisplaySchema = z.object({
   formats: z.record(FormatEntrySchema),
   definitions: z.record(FieldDefinitionSchema).optional(),
-}).passthrough();
+});
 
 const ContractContextSchema = z.object({
   deployments: z.array(DeploymentSchema),


### PR DESCRIPTION
## Summary

Removes `.passthrough()` calls from ERC-7730 parser schemas to enforce strict validation, addressing the security audit recommendation in issue #24.

## Changes

- Removed `.passthrough()` from `MetadataSchema` (info object and top level)
- Removed `.passthrough()` from `FieldDefinitionSchema`
- Removed `.passthrough()` from `FormatEntrySchema`
- Removed `.passthrough()` from `DisplaySchema`

## Why

The security audit identified that permissive schemas could silently accept unexpected fields, potentially leading to future compatibility issues or accepting malformed/malicious descriptor data.

## Testing

- Type-check passes: `bunx tsc --noEmit`
- All 201 tests pass: `bun test`
- Parser-specific tests pass: 6 tests

Closes #24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Validation strictness changes can break consumers that relied on extra/unknown fields in descriptor JSON, but the change is localized to parsing/validation logic.
> 
> **Overview**
> Tightens ERC-7730 descriptor parsing by removing Zod `.passthrough()` from multiple schemas (`MetadataSchema` including `info`, `FieldDefinitionSchema`, `FormatEntrySchema`, `DisplaySchema`), so descriptors with unexpected keys fail validation instead of being silently accepted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b6972ef2ff3f8501e84b015a064f362f46367ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->