### PR TITLE
refactor: consume shared verification source IDs in cli and desktop

### DIFF
--- a/apps/desktop/src/screens/VerifyScreen.tsx
+++ b/apps/desktop/src/screens/VerifyScreen.tsx
@@ -15,6 +15,7 @@ import {
   computeRemainingApprovals,
   normalizeCallSteps,
   verifyCalldata,
+  VERIFICATION_SOURCE_IDS,
 } from "@safelens/core";
 import { TrustBadge } from "@/components/trust-badge";
 import { InterpretationCard } from "@/components/interpretation-card";
@@ -159,7 +160,9 @@ export default function VerifyScreen() {
         setHashMatch(report.hashMatch);
         setPolicyProof(report.policyProof);
         setSimulationVerification(report.simulationVerification);
-        const initialConsensusSource = report.sources.find((source) => source.id === "consensus-proof");
+        const initialConsensusSource = report.sources.find(
+          (source) => source.id === VERIFICATION_SOURCE_IDS.CONSENSUS_PROOF
+        );
         if (initialConsensusSource) {
           setConsensusSourceSummary(initialConsensusSource.summary);
         }
@@ -187,7 +190,9 @@ export default function VerifyScreen() {
               }
             );
             if (!cancelled) {
-              const consensusSource = upgradedReport.sources.find((source) => source.id === "consensus-proof");
+              const consensusSource = upgradedReport.sources.find(
+                (source) => source.id === VERIFICATION_SOURCE_IDS.CONSENSUS_PROOF
+              );
               setConsensusVerification(missingRootResult);
               if (consensusSource) {
                 setConsensusSourceSummary(consensusSource.summary);
@@ -217,7 +222,9 @@ export default function VerifyScreen() {
               }
             );
             if (!cancelled) {
-              const consensusSource = upgradedReport.sources.find((source) => source.id === "consensus-proof");
+              const consensusSource = upgradedReport.sources.find(
+                (source) => source.id === VERIFICATION_SOURCE_IDS.CONSENSUS_PROOF
+              );
               setConsensusVerification(consensusResult);
               if (consensusSource) {
                 setConsensusSourceSummary(consensusSource.summary);
@@ -243,7 +250,9 @@ export default function VerifyScreen() {
               }
             );
             if (!cancelled) {
-              const consensusSource = upgradedReport.sources.find((source) => source.id === "consensus-proof");
+              const consensusSource = upgradedReport.sources.find(
+                (source) => source.id === VERIFICATION_SOURCE_IDS.CONSENSUS_PROOF
+              );
               setConsensusVerification(failedResult);
               if (consensusSource) {
                 setConsensusSourceSummary(consensusSource.summary);

--- a/packages/cli/src/cli.output.test.ts
+++ b/packages/cli/src/cli.output.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, writeFile, rm, readFile } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { spawnSync } from "node:child_process";
-import { createEvidencePackage } from "@safelens/core";
+import { createEvidencePackage, VERIFICATION_SOURCE_IDS } from "@safelens/core";
 import {
   COWSWAP_TWAP_TX,
   CHAIN_ID,
@@ -93,19 +93,19 @@ describe("CLI verify output", () => {
     });
     expect(parsed.sources).toHaveLength(10);
     expect(parsed.sources.map((item: { id: string }) => item.id)).toEqual([
-      "evidence-package",
-      "hash-recompute",
-      "signatures",
-      "signature-scheme-coverage",
-      "safe-owners-threshold",
-      "onchain-policy-proof",
-      "decoded-calldata",
-      "simulation",
-      "consensus-proof",
-      "settings",
+      VERIFICATION_SOURCE_IDS.EVIDENCE_PACKAGE,
+      VERIFICATION_SOURCE_IDS.HASH_RECOMPUTE,
+      VERIFICATION_SOURCE_IDS.SIGNATURES,
+      VERIFICATION_SOURCE_IDS.SIGNATURE_SCHEME_COVERAGE,
+      VERIFICATION_SOURCE_IDS.SAFE_OWNERS_THRESHOLD,
+      VERIFICATION_SOURCE_IDS.ONCHAIN_POLICY_PROOF,
+      VERIFICATION_SOURCE_IDS.DECODED_CALLDATA,
+      VERIFICATION_SOURCE_IDS.SIMULATION,
+      VERIFICATION_SOURCE_IDS.CONSENSUS_PROOF,
+      VERIFICATION_SOURCE_IDS.SETTINGS,
     ]);
     expect(
-      parsed.sources.find((item: { id: string }) => item.id === "settings")?.status
+      parsed.sources.find((item: { id: string }) => item.id === VERIFICATION_SOURCE_IDS.SETTINGS)?.status
     ).toBe("enabled");
   });
 
@@ -191,10 +191,10 @@ describe("CLI verify output", () => {
     expect(result.code).toBe(0);
     const parsed = JSON.parse(result.stdout);
     const settingsSource = parsed.sources.find(
-      (item: { id: string }) => item.id === "settings"
+      (item: { id: string }) => item.id === VERIFICATION_SOURCE_IDS.SETTINGS
     );
     expect(settingsSource).toMatchObject({
-      id: "settings",
+      id: VERIFICATION_SOURCE_IDS.SETTINGS,
       status: "disabled",
     });
     expect(settingsSource?.trust).toBe("api-sourced");


### PR DESCRIPTION
## Summary
This PR removes brittle hardcoded verification source ID strings by reusing the shared `VERIFICATION_SOURCE_IDS` constants from core.

## Changes
- `packages/cli/src/cli.output.test.ts`
  - import and use `VERIFICATION_SOURCE_IDS` for expected source-order assertions and `settings` source lookups.
- `apps/desktop/src/screens/VerifyScreen.tsx`
  - replace repeated `"consensus-proof"` string comparisons with `VERIFICATION_SOURCE_IDS.CONSENSUS_PROOF`.

## Why
Issue #15 calls out source-ID drift risk across core/CLI/tests. This patch reduces that risk by anchoring consumers to canonical IDs exported by core.

## Validation
- `bun run --cwd packages/cli test`
- `bun run --cwd apps/desktop type-check`

Refs #15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change swapping string literals for shared constants; behavior should be unchanged aside from preventing future ID mismatches.
> 
> **Overview**
> Removes hardcoded verification-source ID strings in favor of core-exported `VERIFICATION_SOURCE_IDS` constants.
> 
> Desktop `VerifyScreen` now looks up the consensus-proof source via `VERIFICATION_SOURCE_IDS.CONSENSUS_PROOF`, and CLI JSON output tests assert source ordering and `settings` source selection using the same shared IDs to reduce drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a94d1d6e54008598c5b1ce6eb4a00b398e0a90b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->