### PR TITLE
feat(core): derive decoded calldata trust from local checks

### DIFF
--- a/packages/core/src/lib/trust/__tests__/sources.test.ts
+++ b/packages/core/src/lib/trust/__tests__/sources.test.ts
@@ -54,6 +54,54 @@ describe("buildVerificationSources", () => {
     expect(sources.find((s) => s.id === VERIFICATION_SOURCE_IDS.SIMULATION)?.status).toBe("disabled");
   });
 
+  it("marks decoded calldata as self-verified when all local checks pass", () => {
+    const sources = buildVerificationSources(createVerificationSourceContext({
+      hasSettings: false,
+      hasUnsupportedSignatures: false,
+      hasDecodedData: true,
+      decodedCalldataVerification: "self-verified",
+      hasOnchainPolicyProof: false,
+      hasSimulation: false,
+      hasConsensusProof: false,
+    }));
+
+    const decodedSource = sources.find((s) => s.id === VERIFICATION_SOURCE_IDS.DECODED_CALLDATA);
+    expect(decodedSource?.trust).toBe("self-verified");
+    expect(decodedSource?.summary).toContain("locally verified");
+  });
+
+  it("marks decoded calldata as partial when only some local checks can run", () => {
+    const sources = buildVerificationSources(createVerificationSourceContext({
+      hasSettings: false,
+      hasUnsupportedSignatures: false,
+      hasDecodedData: true,
+      decodedCalldataVerification: "partial",
+      hasOnchainPolicyProof: false,
+      hasSimulation: false,
+      hasConsensusProof: false,
+    }));
+
+    const decodedSource = sources.find((s) => s.id === VERIFICATION_SOURCE_IDS.DECODED_CALLDATA);
+    expect(decodedSource?.trust).toBe("api-sourced");
+    expect(decodedSource?.summary).toContain("partially");
+  });
+
+  it("keeps decoded calldata api-sourced when local checks detect mismatch", () => {
+    const sources = buildVerificationSources(createVerificationSourceContext({
+      hasSettings: false,
+      hasUnsupportedSignatures: false,
+      hasDecodedData: true,
+      decodedCalldataVerification: "mismatch",
+      hasOnchainPolicyProof: false,
+      hasSimulation: false,
+      hasConsensusProof: false,
+    }));
+
+    const decodedSource = sources.find((s) => s.id === VERIFICATION_SOURCE_IDS.DECODED_CALLDATA);
+    expect(decodedSource?.trust).toBe("api-sourced");
+    expect(decodedSource?.summary).toContain("conflicts");
+  });
+
   it("marks settings source disabled when no settings are available", () => {
     const sources = buildVerificationSources(createVerificationSourceContext({
       hasSettings: false,


### PR DESCRIPTION
## Summary
- derive decoded-calldata trust source from local selector/parameter verification instead of always marking it API-sourced
- classify decoded calldata verification into `self-verified`, `partial`, `mismatch`, or `api-only`
- update trust-source wording to explicitly communicate local verification outcomes and mismatch boundaries
- add tests for trust-source status mapping and report-level mismatch behavior

## Why
Issue #29 asks for a local-first trust model for decoded calldata. This PR upgrades the trust boundary so the report reflects local verification results when available, and surfaces explicit mismatch/partial states when local checks fail or are incomplete.

## Validation
- `bun --cwd packages/core test src/lib/trust/__tests__/sources.test.ts`
- `bun --cwd packages/core test src/lib/verify/__tests__/report.test.ts`
- `bun --cwd packages/core type-check`

Closes #29

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how verification reports assign trust for decoded calldata based on new local checks; incorrect classification could mislead users even though it doesn’t alter core signature/hash/policy-proof validation.
> 
> **Overview**
> Decoded calldata is no longer always reported as `api-sourced`: `verifyEvidencePackage` now runs local calldata verification (`normalizeCallSteps` + `verifyCalldata`) and classifies decoded metadata as `self-verified`, `partial`, `mismatch`, or `api-only`.
> 
> `buildVerificationSources` now accepts this decoded-verification status and updates the `decoded-calldata` source’s trust and messaging to explicitly communicate local verification success, partial coverage, or conflicts. Tests are added/updated to cover the new mapping and to ensure mismatched decoded method names keep the source `api-sourced` with conflict wording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32ee1d2fb1faf8e5f100cc65952f89baf8b398da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->