### PR TITLE
refactor(desktop): strongly type interpretation renderer registry

### DIFF
--- a/apps/desktop/src/components/interpretations/registry.tsx
+++ b/apps/desktop/src/components/interpretations/registry.tsx
@@ -35,8 +35,23 @@ export interface EvidenceContext {
 // variant is added to the union, TypeScript will error here until a
 // renderer is provided.
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const RENDERERS: Record<Interpretation["id"], ComponentType<{ details: any; context?: EvidenceContext }>> = {
+type RendererPropsById = {
+  [K in Interpretation["id"]]: {
+    details: Extract<Interpretation, { id: K }>["details"];
+    context?: EvidenceContext;
+  };
+};
+
+type RendererById = {
+  [K in Interpretation["id"]]: ComponentType<RendererPropsById[K]>;
+};
+
+type AnyRendererProps = {
+  details: Interpretation["details"];
+  context?: EvidenceContext;
+};
+
+const RENDERERS: RendererById = {
   "token-transfer": TokenTransferCard,
   "cowswap-twap": CowSwapTwapCard,
   "cowswap-presign": CowSwapPreSignCard,
@@ -44,8 +59,8 @@ const RENDERERS: Record<Interpretation["id"], ComponentType<{ details: any; cont
   "erc7730": ERC7730Card,
 };
 
-export function getRenderer(id: Interpretation["id"]): ComponentType<{ details: Interpretation["details"]; context?: EvidenceContext }> {
-  return RENDERERS[id];
+export function getRenderer(id: Interpretation["id"]): ComponentType<AnyRendererProps> {
+  return RENDERERS[id] as ComponentType<AnyRendererProps>;
 }
 
 // ── Severity-driven styling ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- replace `any` in interpretation renderer registry with an `id -> details` mapped type
- keep registry exhaustiveness guarantees for every `Interpretation['id']`
- expose a union-safe renderer return type for existing `InterpretationCard` usage

## Why
Issue #15 calls out the interpretation renderer registry as a weak typing boundary. This change removes `any` from that path and binds each renderer component to its exact detail payload type.

## Validation
- `bun run --cwd apps/desktop type-check`

Part of #15.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-level refactor only; runtime behavior is unchanged aside from potential compile-time breakages if a renderer’s `details` prop type is incorrect.
> 
> **Overview**
> Refactors the interpretation renderer registry to eliminate `any` by introducing mapped types that bind each `Interpretation["id"]` to the exact `details` payload its card component accepts, while preserving the compile-time exhaustiveness check when new interpretation variants are added.
> 
> Updates `getRenderer` to return a union-safe renderer component type for existing callers (e.g. `InterpretationCard`) via a narrow cast, without changing runtime behavior or the set of registered renderers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8abb40692655d04ab1adc22dc617a3190d76543b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->