### PR TITLE
Refactor ERC-7730 global index parse/build path

### DIFF
--- a/packages/core/src/lib/erc7730/__tests__/global-index.test.ts
+++ b/packages/core/src/lib/erc7730/__tests__/global-index.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getGlobalIndex,
+  resetGlobalIndex,
+  setGlobalDescriptors,
+} from "../global-index";
+
+describe("global ERC-7730 index", () => {
+  afterEach(() => {
+    resetGlobalIndex();
+    vi.restoreAllMocks();
+  });
+
+  it("rebuilds index from raw descriptors and skips invalid entries", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    setGlobalDescriptors([
+      {
+        context: {
+          contract: {
+            deployments: [
+              {
+                chainId: 1,
+                address: "0x1234567890123456789012345678901234567890",
+              },
+            ],
+          },
+        },
+        metadata: { owner: "ValidProtocol" },
+        display: {
+          formats: {
+            "testMethod()": {
+              intent: "Test action",
+              fields: [],
+            },
+          },
+        },
+      },
+      {
+        // Invalid descriptor: missing metadata.owner
+        context: {
+          contract: {
+            deployments: [
+              {
+                chainId: 1,
+                address: "0x9999999999999999999999999999999999999999",
+              },
+            ],
+          },
+        },
+        metadata: {},
+        display: { formats: {} },
+      },
+    ]);
+
+    const index = getGlobalIndex();
+    expect(index.descriptors).toHaveLength(1);
+    expect(index.descriptors[0].metadata.owner).toBe("ValidProtocol");
+    expect(index.entries.size).toBe(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- extract shared `parseAndBuildIndex(rawDescriptors)` helper in ERC-7730 global index
- use the helper in both lazy initialization (`getGlobalIndex`) and explicit override path (`setGlobalDescriptors`)
- add a focused regression test validating invalid descriptors are skipped with warning while valid ones are indexed

## Why
Issue #15 calls out duplicated parse/index rebuild flow in `global-index.ts`. This refactor consolidates the behavior into one internal path to reduce drift risk and keep parse/warn semantics consistent.

## Testing
- `bun --cwd packages/core test src/lib/erc7730/__tests__/global-index.test.ts`
- `bun --cwd packages/core type-check`

Part of #15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that preserves behavior while adding test coverage; main risk is subtle change in how invalid descriptors are filtered/logged during index rebuilds.
> 
> **Overview**
> Refactors the ERC-7730 global descriptor indexing flow by extracting a shared `parseAndBuildIndex()` helper and using it for both lazy initialization (`getGlobalIndex`) and explicit overrides (`setGlobalDescriptors`), ensuring consistent parse+warn behavior and filtering of invalid descriptors.
> 
> Adds a focused Vitest regression test that sets mixed valid/invalid raw descriptors, asserts only valid descriptors are indexed, and verifies a single `console.warn` is emitted for the skipped invalid entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a128c948260f384630057f3ea70d8136ee34731. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->