### PR TITLE
docs: add verification contracts and ERC-7730 update runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ SafeLens generates and verifies evidence packages for Gnosis Safe multisig trans
 
 The desktop verifier ships with `connect-src 'none'` CSP and no shell-open capability, it cannot make network requests during verification. All crypto runs locally using bundled libraries. See [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) for the full model.
 
+## Architecture and runbooks
+
+- Docs index: [`docs/README.md`](docs/README.md)
+- Interpreter precedence contract: [`docs/architecture/interpretation-precedence.md`](docs/architecture/interpretation-precedence.md)
+- Verification source contract: [`docs/architecture/verification-source-contract.md`](docs/architecture/verification-source-contract.md)
+- ERC-7730 bundle update runbook: [`docs/runbooks/erc7730-bundle-update.md`](docs/runbooks/erc7730-bundle-update.md)
+
 ## Verification coverage
 
 - `self-verified`: Safe tx hash recomputation and supported signature recovery.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Docs Index
+
+This folder contains architecture contracts and maintenance runbooks.
+
+## Architecture
+
+- [Interpreter precedence contract](architecture/interpretation-precedence.md)
+- [Verification source contract](architecture/verification-source-contract.md)
+
+## Runbooks
+
+- [ERC-7730 bundle update](runbooks/erc7730-bundle-update.md)

--- a/docs/architecture/interpretation-precedence.md
+++ b/docs/architecture/interpretation-precedence.md
@@ -1,0 +1,37 @@
+# Interpreter Precedence Contract
+
+This document defines the stable precedence rules for transaction interpretation in SafeLens.
+
+## Source of truth
+
+- `packages/core/src/lib/interpret/index.ts`
+
+The `INTERPRETERS` array is ordered and evaluated top-to-bottom. The first non-null interpretation wins.
+
+Current order:
+
+1. `interpretTokenTransfer`
+2. `interpretCowSwapTwap`
+3. `interpretCowSwapPreSign`
+4. `interpretSafePolicy`
+5. `erc7730Interpreter` (dynamic fallback)
+
+## Contract
+
+1. Hand-coded interpreters run before ERC-7730.
+2. ERC-7730 is a fallback and should not override a matched hand-coded interpretation.
+3. Interpreter resolution is deterministic: first match wins.
+4. `disabledIds` filtering is applied after a match. If the matched ID is disabled, evaluation continues.
+
+## Why this exists
+
+Hand-coded interpreters capture protocol-specific logic and safety cues that are harder to express in generic descriptor formats. Keeping them first avoids regressions where generic descriptor matches hide stronger protocol-aware interpretations.
+
+## Contribution guidance
+
+When adding a new interpreter:
+
+1. Decide whether it is protocol-specific enough for hand-coded logic.
+2. If hand-coded, insert it before `erc7730Interpreter`.
+3. Add tests that lock ordering behavior and fallback behavior.
+4. Keep output shape aligned with `packages/core/src/lib/interpret/types.ts`.

--- a/docs/architecture/verification-source-contract.md
+++ b/docs/architecture/verification-source-contract.md
@@ -1,0 +1,68 @@
+# Verification Source Contract
+
+This document defines the shared trust/source contract used by core, CLI, and desktop output.
+
+## Source of truth
+
+- `packages/core/src/lib/trust/sources.ts`
+- `packages/core/src/lib/trust/types.ts`
+- `packages/core/src/lib/verify/index.ts`
+
+## Stable IDs
+
+Use constants from `VERIFICATION_SOURCE_IDS` and `GENERATION_SOURCE_IDS` instead of hardcoded strings.
+
+Why:
+
+1. Shared IDs keep CLI/UI/tests aligned.
+2. Refactors remain compile-safe when IDs evolve.
+
+## Context builder
+
+Always construct context via `createVerificationSourceContext(...)`.
+
+This enforces defaults from `DEFAULT_VERIFICATION_SOURCE_CONTEXT` and avoids field drift at call sites.
+
+## Consensus trust matrix
+
+Consensus trust for `consensus-proof` is derived from:
+
+- `hasConsensusProof`
+- `consensusVerified`
+- `consensusMode` (`beacon`, `opstack`, `linea`)
+
+Rules:
+
+1. `hasConsensusProof=false`:
+   - source status: `disabled`
+   - trust: `rpc-sourced`
+   - summary/detail explain proof omission and fallback trust
+2. `hasConsensusProof=true`, `consensusVerified=false`:
+   - source status: `enabled`
+   - trust: `rpc-sourced`
+   - summary/detail explain included-but-not-upgraded proof
+3. `hasConsensusProof=true`, `consensusVerified=true`:
+   - source status: `enabled`
+   - trust:
+     - beacon -> `consensus-verified-beacon`
+     - opstack -> `consensus-verified-opstack`
+     - linea -> `consensus-verified-linea`
+
+For OP Stack and Linea, summary/detail must preserve the non-equivalence boundary to Beacon light-client finality.
+
+## Decoded calldata trust matrix
+
+`decoded-calldata` trust is derived from `decodedCalldataVerification`:
+
+1. `self-verified` -> trust `self-verified`
+2. `partial` -> trust `api-sourced` with partial-verification wording
+3. `mismatch` -> trust `api-sourced` with explicit mismatch wording
+4. `api-only` or omitted -> trust `api-sourced`
+
+## Required tests
+
+When changing this contract, update and run:
+
+- `packages/core/src/lib/trust/__tests__/sources.test.ts`
+- `packages/core/src/lib/verify/__tests__/report.test.ts`
+- `packages/cli/src/cli.output.test.ts` (if output wording or IDs change)

--- a/docs/runbooks/erc7730-bundle-update.md
+++ b/docs/runbooks/erc7730-bundle-update.md
@@ -1,0 +1,54 @@
+# ERC-7730 Bundle Update Runbook
+
+This runbook defines the minimum review and validation steps for updating bundled ERC-7730 descriptors.
+
+## Scope
+
+This applies to:
+
+- `packages/core/src/lib/erc7730/descriptors/index.ts`
+- `packages/core/src/lib/settings/defaults.ts`
+
+## Pinned source contract
+
+SafeLens pins descriptor provenance to a specific upstream commit:
+
+- `CLEAR_SIGNING_REGISTRY_COMMIT` in `packages/core/src/lib/settings/defaults.ts`
+- Header comments and source links in `packages/core/src/lib/erc7730/descriptors/index.ts`
+
+When updating descriptors, keep these references in sync.
+
+## Update procedure
+
+1. Select target commit in `LedgerHQ/clear-signing-erc7730-registry`.
+2. Regenerate or update `packages/core/src/lib/erc7730/descriptors/index.ts` imports/array from that commit.
+3. Update `CLEAR_SIGNING_REGISTRY_COMMIT` in `packages/core/src/lib/settings/defaults.ts`.
+4. Confirm descriptor source URLs and commit references point to the same commit in both files.
+5. Review descriptor diff for removed/renamed protocols and deployment changes.
+
+## Required validation
+
+Run at minimum:
+
+```bash
+bun --cwd packages/core test src/lib/erc7730/__tests__/parser.test.ts
+bun --cwd packages/core test src/lib/erc7730/__tests__/index.test.ts
+bun --cwd packages/core test src/lib/erc7730/__tests__/integration.test.ts
+bun --cwd packages/core test src/lib/settings/__tests__/defaults.test.ts
+bun --cwd packages/core type-check
+```
+
+If interpretation output changes materially, also run:
+
+```bash
+bun --cwd packages/core test src/lib/interpret/__tests__/token-transfer.test.ts
+bun --cwd packages/cli test
+```
+
+## Review checklist
+
+1. Commit pin is updated exactly once and reused consistently.
+2. No manual edits to generated descriptor content beyond provenance metadata updates.
+3. Descriptor parsing/build tests pass.
+4. Settings defaults still build deterministic chain/contract/token entries.
+5. PR notes include upstream commit URL and a short summary of descriptor coverage changes.


### PR DESCRIPTION
## Summary

Adds the missing documentation contracts from issue #15 so high-coupling behavior is explicit and discoverable from repo root docs.

## Changes

- add `docs/README.md` docs index
- add `docs/architecture/interpretation-precedence.md`
  - documents hand-coded interpreter precedence and ERC-7730 fallback contract
- add `docs/architecture/verification-source-contract.md`
  - documents shared verification source IDs and context builder usage
  - documents consensus trust matrix (`hasConsensusProof`, `consensusVerified`, `consensusMode`)
  - documents decoded calldata trust matrix
- add `docs/runbooks/erc7730-bundle-update.md`
  - documents pinned commit contract and update procedure
  - includes required validation commands and review checklist
- link docs and runbooks from `README.md`

## Why

Issue #15 calls out missing documentation for:

- interpreter precedence contract
- consensus/source semantics contract
- ERC-7730 bundle update workflow

This PR addresses those tracks and makes them discoverable from root docs.

Refs #15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new markdown files and README links) with no runtime or build impact.
> 
> **Overview**
> Adds a new `docs/` documentation hub and links it from the root `README.md` under a new **Architecture and runbooks** section.
> 
> Documents two high-coupling “contracts”: interpreter precedence/ERC-7730 fallback ordering and verification source/trust semantics (including consensus and decoded-calldata trust matrices), and adds an ERC-7730 descriptor bundle update runbook with commit-pinning requirements, validation commands, and a review checklist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7eb95ff7a0de6939cdea77c2f407ea1d35cd48d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->