### PR TITLE
Deduplicate CowSwap token formatting with shared token-utils

### DIFF
--- a/packages/core/src/lib/interpret/__tests__/token-utils.test.ts
+++ b/packages/core/src/lib/interpret/__tests__/token-utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { formatTokenAmount } from "../token-utils";
+
+describe("formatTokenAmount", () => {
+  it("formats standard 18-decimal values", () => {
+    expect(formatTokenAmount("1500000000000000000", 18)).toBe("1.5000");
+  });
+
+  it("uses exact BigInt exponent math for high decimals", () => {
+    const raw = (BigInt(10) ** BigInt(24)).toString();
+    expect(formatTokenAmount(raw, 24)).toBe("1.0000");
+  });
+});

--- a/packages/core/src/lib/interpret/cowswap-twap.ts
+++ b/packages/core/src/lib/interpret/cowswap-twap.ts
@@ -5,49 +5,15 @@
  * TWAP (Time-Weighted Average Price) orders via the Composable Order Framework.
  */
 
-import type { CowSwapTwapDetails, TokenInfo, Interpreter } from "./types";
+import type { CowSwapTwapDetails, Interpreter } from "./types";
+import { resolveToken, formatTokenAmount } from "./token-utils";
 
 // ── Well-known addresses (Ethereum Mainnet) ────────────────────────────
 
 const COW_TWAP_HANDLER = "0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5";
 const COW_COMPOSABLE_COW = "0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74";
 
-const KNOWN_TOKENS: Record<string, { symbol: string; decimals: number }> = {
-  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": {
-    symbol: "WETH",
-    decimals: 18,
-  },
-  "0x6b175474e89094c44da98b954eedeac495271d0f": {
-    symbol: "DAI",
-    decimals: 18,
-  },
-  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": {
-    symbol: "USDC",
-    decimals: 6,
-  },
-  "0xdac17f958d2ee523a2206206994597c13d831ec7": {
-    symbol: "USDT",
-    decimals: 6,
-  },
-};
-
 // ── Helpers ─────────────────────────────────────────────────────────────
-
-function resolveToken(address: string): TokenInfo {
-  const known = KNOWN_TOKENS[address.toLowerCase()];
-  return known
-    ? { address, symbol: known.symbol, decimals: known.decimals }
-    : { address };
-}
-
-function formatTokenAmount(raw: string, decimals: number): string {
-  const value = BigInt(raw);
-  const divisor = BigInt(10 ** decimals);
-  const whole = value / divisor;
-  const remainder = value % divisor;
-  const fractional = remainder.toString().padStart(decimals, "0").slice(0, 4);
-  return `${whole}.${fractional}`;
-}
 
 function formatDuration(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;


### PR DESCRIPTION
## Summary
- replace local token metadata/formatting helpers in `cowswap-twap` with shared `token-utils`
- remove duplicate known-token map from the CowSwap interpreter
- add a regression test for high-decimal formatting to guard against precision drift

## Why
Issue #15 calls out duplicated interpreter logic and precision-risk in amount formatting. This PR consolidates CowSwap onto the shared helper path and adds coverage for the BigInt exponent safety edge case.

## Validation
- `bun --cwd packages/core test`
- `bun --cwd packages/core type-check`

Part of #15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a refactor to reuse existing utilities plus tests; behavior should remain the same aside from safer handling of very large `decimals`.
> 
> **Overview**
> Deduplicates CowSwap TWAP token handling by removing the interpreter-local known-token map and `resolveToken`/`formatTokenAmount` helpers, and instead importing them from shared `token-utils`.
> 
> Adds `token-utils` unit tests covering both typical 18-decimal formatting and a regression case ensuring `formatTokenAmount` uses exact `BigInt(10) ** BigInt(decimals)` math for high decimal counts (avoiding `10 ** decimals` precision/overflow issues).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c59d3a7488b148cdac9138f2f8fc0dad23b91d8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->