### PR TITLE
fix(core): keep simulation trust rpc-sourced until local replay exists

### DIFF
--- a/packages/core/src/lib/trust/__tests__/sources.test.ts
+++ b/packages/core/src/lib/trust/__tests__/sources.test.ts
@@ -192,6 +192,42 @@ describe("buildVerificationSources", () => {
     expect(simSource?.summary).toContain("simulated");
   });
 
+  it("explains replay-not-run when witness checks pass but local replay is unavailable", () => {
+    const sources = buildVerificationSources(createVerificationSourceContext({
+      hasSettings: false,
+      hasUnsupportedSignatures: false,
+      hasDecodedData: false,
+      hasOnchainPolicyProof: true,
+      hasSimulation: true,
+      hasSimulationWitness: true,
+      simulationTrust: "rpc-sourced",
+      simulationVerificationReason: "simulation-replay-not-run",
+      hasConsensusProof: false,
+    }));
+
+    const simSource = sources.find((s) => s.id === VERIFICATION_SOURCE_IDS.SIMULATION);
+    expect(simSource?.trust).toBe("rpc-sourced");
+    expect(simSource?.summary).toContain("local replay was not run");
+  });
+
+  it("explains witness-proof-failed when witness checks fail", () => {
+    const sources = buildVerificationSources(createVerificationSourceContext({
+      hasSettings: false,
+      hasUnsupportedSignatures: false,
+      hasDecodedData: false,
+      hasOnchainPolicyProof: true,
+      hasSimulation: true,
+      hasSimulationWitness: true,
+      simulationTrust: "rpc-sourced",
+      simulationVerificationReason: "simulation-witness-proof-failed",
+      hasConsensusProof: false,
+    }));
+
+    const simSource = sources.find((s) => s.id === VERIFICATION_SOURCE_IDS.SIMULATION);
+    expect(simSource?.trust).toBe("rpc-sourced");
+    expect(simSource?.summary).toContain("witness checks failed");
+  });
+
   it("respects custom trust levels for policy proof and simulation", () => {
     const sources = buildVerificationSources(createVerificationSourceContext({
       hasSettings: false,

--- a/packages/core/src/lib/verify/__tests__/simulation-witness.test.ts
+++ b/packages/core/src/lib/verify/__tests__/simulation-witness.test.ts
@@ -83,8 +83,8 @@ function makeWitness(
   };
 }
 
-describe("verifyEvidencePackage simulation witness trust upgrades", () => {
-  it("upgrades simulation source to proof-verified when witness and policy proof validate", async () => {
+describe("verifyEvidencePackage simulation witness trust handling", () => {
+  it("keeps simulation source rpc-sourced until local replay verification exists", async () => {
     const base = createEvidencePackage(COWSWAP_TWAP_TX, CHAIN_ID, TX_URL);
     const simulation = makeSimulation();
     const enriched = {
@@ -101,7 +101,8 @@ describe("verifyEvidencePackage simulation witness trust upgrades", () => {
     const simulationSource = report.sources.find(
       (source) => source.id === VERIFICATION_SOURCE_IDS.SIMULATION
     );
-    expect(simulationSource?.trust).toBe("proof-verified");
+    expect(simulationSource?.trust).toBe("rpc-sourced");
+    expect(simulationSource?.summary).toContain("local replay was not run");
   });
 
   it("keeps simulation source rpc-sourced when witness does not align with policy anchor", async () => {

--- a/packages/core/src/lib/verify/index.ts
+++ b/packages/core/src/lib/verify/index.ts
@@ -233,17 +233,15 @@ function buildReportSources(
 
   const simulationTrust =
     options.evidence.simulation &&
-    options.simulationVerification?.valid &&
-    options.simulationWitnessVerification?.valid &&
-    options.policyProof?.valid &&
-    options.evidence.onchainPolicyProof &&
-    options.evidence.simulationWitness &&
-    options.evidence.simulationWitness.stateRoot.toLowerCase() ===
-      options.evidence.onchainPolicyProof.stateRoot.toLowerCase() &&
-    options.evidence.simulationWitness.blockNumber ===
-      options.evidence.onchainPolicyProof.blockNumber
-      ? "proof-verified"
+    options.evidence.simulationWitness
+      ? "rpc-sourced"
       : options.evidence.simulation?.trust;
+  const simulationVerificationReason =
+    options.evidence.simulation && options.evidence.simulationWitness
+      ? options.simulationWitnessVerification?.valid
+        ? "simulation-replay-not-run"
+        : "simulation-witness-proof-failed"
+      : undefined;
   const decodedSteps = options.evidence.dataDecoded
     ? normalizeCallSteps(
         options.evidence.dataDecoded,
@@ -278,6 +276,8 @@ function buildReportSources(
     decodedCalldataVerification,
     hasOnchainPolicyProof: Boolean(options.evidence.onchainPolicyProof),
     hasSimulation: Boolean(options.evidence.simulation),
+    hasSimulationWitness: Boolean(options.evidence.simulationWitness),
+    simulationVerificationReason,
     hasConsensusProof: Boolean(options.evidence.consensusProof),
     // After successful local Merkle verification, upgrade trust from
     // "rpc-sourced" to "proof-verified", the proof was cryptographically


### PR DESCRIPTION
## Summary
- prevent `simulation` source trust from upgrading to `proof-verified` based on witness anchoring checks alone
- keep witness-present simulation trust at `rpc-sourced` until a real local replay verifier path exists
- surface deterministic simulation trust messaging for:
  - `simulation-replay-not-run`
  - `simulation-witness-proof-failed`

## Why
Issue #30 tracks full local replay as the requirement for fully local simulation verification. Current behavior could over-claim proof verification without replay.

## Validation
- `bun --cwd packages/core test`
- `bun --cwd packages/core type-check`

Refs #30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trust classification and explanatory messaging in verification output, which could affect downstream UI/consumer expectations, but does not alter cryptographic verification itself.
> 
> **Overview**
> Simulation verification no longer upgrades the `SIMULATION` source trust to `proof-verified` when a `simulationWitness` is present; it now stays `rpc-sourced` until a full local replay verifier exists.
> 
> Adds a deterministic `simulationVerificationReason`/`SimulationVerificationReason` to drive user-facing `summary`/`detail` text for the simulation source, distinguishing *witness proof failed* vs *replay not run*, and updates/extends tests to assert the new trust behavior and messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2861b484fc82aae60c08b4f7a9969bf8ab9d24b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->