### PR TITLE
fix(core): surface missing simulation witness trust reason

### DIFF
--- a/packages/core/src/lib/trust/__tests__/sources.test.ts
+++ b/packages/core/src/lib/trust/__tests__/sources.test.ts
@@ -210,6 +210,24 @@ describe("buildVerificationSources", () => {
     expect(simSource?.summary).toContain("local replay was not run");
   });
 
+  it("explains missing witness when simulation has no witness artifact", () => {
+    const sources = buildVerificationSources(createVerificationSourceContext({
+      hasSettings: false,
+      hasUnsupportedSignatures: false,
+      hasDecodedData: false,
+      hasOnchainPolicyProof: false,
+      hasSimulation: true,
+      hasSimulationWitness: false,
+      simulationTrust: "rpc-sourced",
+      simulationVerificationReason: "missing-simulation-witness",
+      hasConsensusProof: false,
+    }));
+
+    const simSource = sources.find((s) => s.id === VERIFICATION_SOURCE_IDS.SIMULATION);
+    expect(simSource?.trust).toBe("rpc-sourced");
+    expect(simSource?.summary).toContain("No simulation witness was included");
+  });
+
   it("explains witness-proof-failed when witness checks fail", () => {
     const sources = buildVerificationSources(createVerificationSourceContext({
       hasSettings: false,

--- a/packages/core/src/lib/trust/sources.ts
+++ b/packages/core/src/lib/trust/sources.ts
@@ -12,6 +12,7 @@ export type DecodedCalldataVerificationStatus =
   | "mismatch"
   | "api-only";
 export type SimulationVerificationReason =
+  | "missing-simulation-witness"
   | "simulation-replay-not-run"
   | "simulation-witness-proof-failed";
 
@@ -306,13 +307,17 @@ export function buildVerificationSources(
           title: "Transaction simulation",
           trust: context.simulationTrust ?? "rpc-sourced",
           summary:
-            context.simulationVerificationReason === "simulation-witness-proof-failed"
+            context.simulationVerificationReason === "missing-simulation-witness"
+              ? "No simulation witness was included; simulation remains RPC-sourced."
+              : context.simulationVerificationReason === "simulation-witness-proof-failed"
               ? "Simulation witness checks failed; simulation remains RPC-sourced."
               : context.simulationVerificationReason === "simulation-replay-not-run"
                 ? "Simulation witness checks passed, but local replay was not run."
                 : "Transaction simulated via execTransaction with state overrides.",
           detail:
-            context.simulationVerificationReason === "simulation-witness-proof-failed"
+            context.simulationVerificationReason === "missing-simulation-witness"
+              ? "Simulation output was packaged without a witness artifact. Treat simulation outcome as RPC-trusted until witness generation and local replay verification are both available."
+              : context.simulationVerificationReason === "simulation-witness-proof-failed"
               ? "Simulation output was compared against witness metadata, but witness proof validation failed. Treat simulation outcome as RPC-trusted until witness and replay verification both pass."
               : context.simulationVerificationReason === "simulation-replay-not-run"
                 ? "Witness anchoring checks passed, but this verifier path does not execute a full local EVM replay yet. Trust remains RPC-sourced until replay verification is available and passes."

--- a/packages/core/src/lib/verify/__tests__/simulation-witness.test.ts
+++ b/packages/core/src/lib/verify/__tests__/simulation-witness.test.ts
@@ -84,6 +84,26 @@ function makeWitness(
 }
 
 describe("verifyEvidencePackage simulation witness trust handling", () => {
+  it("keeps simulation source rpc-sourced when witness artifact is missing", async () => {
+    const base = createEvidencePackage(COWSWAP_TWAP_TX, CHAIN_ID, TX_URL);
+    const simulation = makeSimulation();
+    const enriched = {
+      ...base,
+      version: "1.2" as const,
+      onchainPolicyProof: makeOnchainProof(),
+      simulation,
+    };
+
+    const report = await verifyEvidencePackage(enriched);
+    expect(report.simulationVerification?.valid).toBe(true);
+    expect(report.simulationWitnessVerification).toBeUndefined();
+    const simulationSource = report.sources.find(
+      (source) => source.id === VERIFICATION_SOURCE_IDS.SIMULATION
+    );
+    expect(simulationSource?.trust).toBe("rpc-sourced");
+    expect(simulationSource?.summary).toContain("No simulation witness was included");
+  });
+
   it("keeps simulation source rpc-sourced until local replay verification exists", async () => {
     const base = createEvidencePackage(COWSWAP_TWAP_TX, CHAIN_ID, TX_URL);
     const simulation = makeSimulation();

--- a/packages/core/src/lib/verify/index.ts
+++ b/packages/core/src/lib/verify/index.ts
@@ -237,11 +237,13 @@ function buildReportSources(
       ? "rpc-sourced"
       : options.evidence.simulation?.trust;
   const simulationVerificationReason =
-    options.evidence.simulation && options.evidence.simulationWitness
-      ? options.simulationWitnessVerification?.valid
-        ? "simulation-replay-not-run"
-        : "simulation-witness-proof-failed"
-      : undefined;
+    !options.evidence.simulation
+      ? undefined
+      : !options.evidence.simulationWitness
+        ? "missing-simulation-witness"
+        : options.simulationWitnessVerification?.valid
+          ? "simulation-replay-not-run"
+          : "simulation-witness-proof-failed";
   const decodedSteps = options.evidence.dataDecoded
     ? normalizeCallSteps(
         options.evidence.dataDecoded,


### PR DESCRIPTION
## Summary
- add an explicit simulation verification reason for packages that include simulation output without a witness artifact (`missing-simulation-witness`)
- wire the reason in report source construction so this path is deterministic
- update trust-source messaging to clearly distinguish missing witness vs failed witness checks vs replay-not-run
- add regression tests for trust-source rendering and end-to-end `verifyEvidencePackage` behavior

## Why
Issue #30 tracks stronger local simulation verification semantics. This change tightens current trust boundaries by making the "missing witness" case explicit and machine-readable, instead of collapsing into generic simulation wording.

## Changes
- `packages/core/src/lib/verify/index.ts`
  - emits `missing-simulation-witness` when `simulation` exists but `simulationWitness` is absent
- `packages/core/src/lib/trust/sources.ts`
  - extends `SimulationVerificationReason` with `missing-simulation-witness`
  - adds dedicated summary/detail copy for that branch
- `packages/core/src/lib/trust/__tests__/sources.test.ts`
  - adds coverage for missing witness source messaging
- `packages/core/src/lib/verify/__tests__/simulation-witness.test.ts`
  - adds end-to-end test for simulation present + witness absent

## Validation
- `bun --cwd packages/core test src/lib/trust/__tests__/sources.test.ts`
- `bun --cwd packages/core test src/lib/verify/__tests__/simulation-witness.test.ts`
- `bun --cwd packages/core type-check`

Refs #30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to adding a new enum branch and user-facing messaging plus tests; no changes to cryptographic verification behavior or trust upgrades.
> 
> **Overview**
> Makes simulation trust reporting deterministic when a package includes `simulation` but omits `simulationWitness` by introducing a new `SimulationVerificationReason` (`missing-simulation-witness`) and emitting it from `verifyEvidencePackage` report source construction.
> 
> Updates the simulation source `summary`/`detail` messaging to clearly differentiate *missing witness* vs *witness-proof-failed* vs *replay-not-run*, and adds regression tests covering both trust-source rendering and end-to-end `verifyEvidencePackage` behavior for the missing-witness case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c201f779434c02ea8d17a09d17aed2d169706b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->