### PR TITLE
fix(tauri): pin helios-consensus-core revision for reproducible builds

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-plugin-dialog = "2"
 window-vibrancy = "0.5"
 
 # Helios consensus verification (Phase 4)
-helios-consensus-core = { git = "https://github.com/a16z/helios", package = "helios-consensus-core" }
+helios-consensus-core = { git = "https://github.com/a16z/helios", rev = "582fda319ed1ecb5fb82c71f4fa755a32e01031a", package = "helios-consensus-core" }
 alloy = { version = "1.0.3", default-features = false, features = ["consensus", "ssz"] }
 tree_hash = "0.10.0"
 eyre = "0.6.8"


### PR DESCRIPTION
## Summary
- pin `helios-consensus-core` to an explicit git `rev` in `apps/desktop/src-tauri/Cargo.toml`
- align dependency hygiene with existing pinned `ethereum_hashing` patch
- remove non-determinism from fresh builds while `Cargo.lock` remains intentionally ignored for Tauri

## Why
PR #27 left an unresolved review thread noting that `helios-consensus-core` was unpinned. For consensus proof verification code paths, reproducible dependency resolution is critical.

## Validation
- `cargo check` (in `apps/desktop/src-tauri`) passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency metadata-only change; main risk is unintentionally freezing to a commit with bugs or incompatibilities.
> 
> **Overview**
> Pins the Tauri desktop app’s `helios-consensus-core` dependency to a specific git `rev` in `apps/desktop/src-tauri/Cargo.toml`, preventing upstream changes from altering fresh builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffe495c3abbdfc3df52eb8d97a0a27dccabdd742. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->