### PR TITLE
Phase A: OP/Linea gates + desktop simulation replay skeleton

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ eyre = "0.6.8"
 hex = "0.4"
 typenum = "1"
 time = { version = "0.3", features = ["parsing"] }
+revm = { version = "30", default-features = false, features = ["std"] }
 
 [patch.crates-io]
 ethereum_hashing = { git = "https://github.com/ncitron/ethereum_hashing", rev = "7ee70944ed4fabe301551da8c447e4f4ae5e6c35" }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 use tauri::Manager;
 
 mod consensus;
+mod simulation_replay;
 
 #[tauri::command]
 fn verify_consensus_proof(
@@ -9,11 +10,21 @@ fn verify_consensus_proof(
     Ok(consensus::verify_consensus_proof(input))
 }
 
+#[tauri::command]
+fn verify_simulation_replay(
+    input: simulation_replay::SimulationReplayInput,
+) -> Result<simulation_replay::SimulationReplayVerificationResult, String> {
+    Ok(simulation_replay::verify_simulation_replay(input))
+}
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-        .invoke_handler(tauri::generate_handler![verify_consensus_proof])
+        .invoke_handler(tauri::generate_handler![
+            verify_consensus_proof,
+            verify_simulation_replay
+        ])
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();
 

--- a/apps/desktop/src-tauri/src/simulation_replay.rs
+++ b/apps/desktop/src-tauri/src/simulation_replay.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SimulationReplayInput {
+    pub chain_id: u64,
+    pub safe_address: String,
+    pub transaction: Value,
+    pub simulation: Value,
+    pub simulation_witness: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SimulationReplayVerificationResult {
+    pub executed: bool,
+    pub success: bool,
+    pub reason: String,
+    pub error: Option<String>,
+}
+
+pub fn verify_simulation_replay(
+    input: SimulationReplayInput,
+) -> SimulationReplayVerificationResult {
+    // Phase A skeleton only: wire typed command boundary and deterministic
+    // reason surface before adding the full witness->revm replay engine.
+    let _ = (
+        input.chain_id,
+        input.safe_address,
+        input.transaction,
+        input.simulation,
+        input.simulation_witness,
+    );
+
+    SimulationReplayVerificationResult {
+        executed: false,
+        success: false,
+        reason: "simulation-replay-not-run".to_string(),
+        error: None,
+    }
+}

--- a/apps/generator/app/page.tsx
+++ b/apps/generator/app/page.tsx
@@ -34,6 +34,7 @@ import { AddressDisplay } from "@/components/address-display";
 import type { EvidencePackage, SafeTransaction } from "@safelens/core";
 
 const generationSources = buildGenerationSources();
+const opstackConsensusEnabled = process.env.NEXT_PUBLIC_ENABLE_OPSTACK_CONSENSUS === "1";
 const lineaConsensusEnabled = process.env.NEXT_PUBLIC_ENABLE_LINEA_CONSENSUS === "1";
 const RPC_PING_TIMEOUT_MS = 3500;
 const DEFAULT_RPC_CANDIDATES: Record<number, [string, string]> = {
@@ -414,6 +415,7 @@ export default function AnalyzePage() {
               ? resolvedRpcUrl
               : undefined,
           enableExperimentalLineaConsensus: lineaConsensusEnabled,
+          enableExperimentalOpstackConsensus: opstackConsensusEnabled,
         });
       } catch (err) {
         consensusProofFailed = true;

--- a/packages/cli/src/cli.output.test.ts
+++ b/packages/cli/src/cli.output.test.ts
@@ -316,9 +316,10 @@ describe("CLI verify output", () => {
     expect(result.stderr).toContain("Invalid JSON format");
   });
 
-  it("documents the experimental Linea consensus analyze flag in help output", () => {
+  it("documents experimental consensus analyze flags in help output", () => {
     const result = runCli([]);
     expect(result.code).toBe(0);
+    expect(result.stdout).toContain("--enable-experimental-opstack-consensus");
     expect(result.stdout).toContain("--enable-experimental-linea-consensus");
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -67,6 +67,7 @@ Usage:
 
 Options:
   --rpc-url <url>   Fetch on-chain policy proof + simulate transaction via RPC
+  --enable-experimental-opstack-consensus  Enable experimental OP Stack consensus envelope fetch in analyze
   --enable-experimental-linea-consensus  Enable experimental Linea consensus envelope fetch in analyze
 
 Examples:
@@ -431,6 +432,7 @@ async function runAnalyze(args: string[]) {
   const format = getOutputFormat(args, "text");
 
   const rpcUrl = getFlag(args, "--rpc-url");
+  const enableExperimentalOpstackConsensus = hasFlag(args, "--enable-experimental-opstack-consensus");
   const enableExperimentalLineaConsensus = hasFlag(args, "--enable-experimental-linea-consensus");
 
   const parsed = parseSafeUrlFlexible(url);
@@ -468,10 +470,14 @@ async function runAnalyze(args: string[]) {
     try {
       const consensusOptions: {
         rpcUrl?: string;
+        enableExperimentalOpstackConsensus?: boolean;
         enableExperimentalLineaConsensus?: boolean;
       } = {};
       if ((consensusMode === "opstack" || consensusMode === "linea") && rpcUrl) {
         consensusOptions.rpcUrl = rpcUrl;
+      }
+      if (enableExperimentalOpstackConsensus) {
+        consensusOptions.enableExperimentalOpstackConsensus = true;
       }
       if (enableExperimentalLineaConsensus) {
         consensusOptions.enableExperimentalLineaConsensus = true;

--- a/packages/core/src/lib/consensus/__tests__/index.test.ts
+++ b/packages/core/src/lib/consensus/__tests__/index.test.ts
@@ -52,6 +52,7 @@ describe("consensus mode routing", () => {
     const proof = await fetchConsensusProof(10, {
       rpcUrl: "https://example.invalid/rpc",
       blockTag: "finalized",
+      enableExperimentalOpstackConsensus: true,
     });
 
     expect(proof).toMatchObject({
@@ -85,6 +86,7 @@ describe("consensus mode routing", () => {
     const proof = await fetchConsensusProof(8453, {
       rpcUrl: "https://example.invalid/rpc",
       blockTag: "finalized",
+      enableExperimentalOpstackConsensus: true,
     });
 
     expect(proof).toMatchObject({
@@ -123,6 +125,14 @@ describe("consensus mode routing", () => {
     expect("proofPayload" in proof).toBe(true);
   });
 
+  it("rejects opstack envelopes when rollout feature flag is disabled", async () => {
+    await expect(fetchConsensusProof(10)).rejects.toMatchObject({
+      code: UNSUPPORTED_CONSENSUS_MODE_ERROR_CODE,
+      consensusMode: "opstack",
+      reason: "disabled-by-feature-flag",
+    });
+  });
+
   it("rejects linea envelopes when rollout feature flag is disabled", async () => {
     await expect(fetchConsensusProof(59144)).rejects.toMatchObject({
       code: UNSUPPORTED_CONSENSUS_MODE_ERROR_CODE,
@@ -142,6 +152,7 @@ describe("consensus mode routing", () => {
       fetchConsensusProof(10, {
         rpcUrl: "https://example.invalid/rpc",
         blockTag: "latest",
+        enableExperimentalOpstackConsensus: true,
       })
     ).rejects.toThrow(
       "Execution consensus envelopes require blockTag='finalized'; received 'latest'."

--- a/packages/core/src/lib/consensus/index.ts
+++ b/packages/core/src/lib/consensus/index.ts
@@ -24,6 +24,11 @@ export interface FetchConsensusProofOptions
   extends BeaconFetchConsensusProofOptions,
     FetchExecutionConsensusProofOptions {
   /**
+   * Rollout gate for experimental OP Stack consensus envelopes.
+   * Default is false until verifier/runtime hardening is complete.
+   */
+  enableExperimentalOpstackConsensus?: boolean;
+  /**
    * Rollout gate for experimental Linea consensus envelopes.
    * Default is false until the full verifier path is complete.
    */
@@ -70,6 +75,17 @@ export async function fetchConsensusProof(
 
   if (capability.consensusMode === "beacon") {
     return fetchBeaconConsensusProof(chainId, options);
+  }
+
+  if (
+    capability.consensusMode === "opstack" &&
+    options.enableExperimentalOpstackConsensus !== true
+  ) {
+    throw new UnsupportedConsensusModeError(
+      chainId,
+      capability.consensusMode,
+      "disabled-by-feature-flag"
+    );
   }
 
   if (

--- a/packages/core/src/lib/trust/__tests__/sources.test.ts
+++ b/packages/core/src/lib/trust/__tests__/sources.test.ts
@@ -246,6 +246,24 @@ describe("buildVerificationSources", () => {
     expect(simSource?.summary).toContain("witness checks failed");
   });
 
+  it("explains replay-exec-error when local replay execution fails", () => {
+    const sources = buildVerificationSources(createVerificationSourceContext({
+      hasSettings: false,
+      hasUnsupportedSignatures: false,
+      hasDecodedData: false,
+      hasOnchainPolicyProof: true,
+      hasSimulation: true,
+      hasSimulationWitness: true,
+      simulationTrust: "rpc-sourced",
+      simulationVerificationReason: "simulation-replay-exec-error",
+      hasConsensusProof: false,
+    }));
+
+    const simSource = sources.find((s) => s.id === VERIFICATION_SOURCE_IDS.SIMULATION);
+    expect(simSource?.trust).toBe("rpc-sourced");
+    expect(simSource?.summary).toContain("Local replay execution failed");
+  });
+
   it("respects custom trust levels for policy proof and simulation", () => {
     const sources = buildVerificationSources(createVerificationSourceContext({
       hasSettings: false,

--- a/packages/core/src/lib/trust/sources.ts
+++ b/packages/core/src/lib/trust/sources.ts
@@ -14,6 +14,7 @@ export type DecodedCalldataVerificationStatus =
 export type SimulationVerificationReason =
   | "missing-simulation-witness"
   | "simulation-replay-not-run"
+  | "simulation-replay-exec-error"
   | "simulation-witness-proof-failed";
 
 interface ConsensusSourceMetadata {
@@ -313,6 +314,8 @@ export function buildVerificationSources(
               ? "Simulation witness checks failed; simulation remains RPC-sourced."
               : context.simulationVerificationReason === "simulation-replay-not-run"
                 ? "Simulation witness checks passed, but local replay was not run."
+                : context.simulationVerificationReason === "simulation-replay-exec-error"
+                  ? "Local replay execution failed; simulation remains RPC-sourced."
                 : "Transaction simulated via execTransaction with state overrides.",
           detail:
             context.simulationVerificationReason === "missing-simulation-witness"
@@ -321,6 +324,8 @@ export function buildVerificationSources(
               ? "Simulation output was compared against witness metadata, but witness proof validation failed. Treat simulation outcome as RPC-trusted until witness and replay verification both pass."
               : context.simulationVerificationReason === "simulation-replay-not-run"
                 ? "Witness anchoring checks passed, but this verifier path does not execute a full local EVM replay yet. Trust remains RPC-sourced until replay verification is available and passes."
+                : context.simulationVerificationReason === "simulation-replay-exec-error"
+                  ? "Witness anchoring checks passed, but local replay execution failed. Treat simulation outcome as RPC-trusted until replay verification executes and passes."
                 : "Simulation was run using storage-override technique. Trust level depends on how the simulation was sourced: rpc-sourced if from a standard RPC, proof-verified only when a full local replay verifier confirms the packaged result.",
           status: "enabled" as VerificationSourceStatus,
         }


### PR DESCRIPTION
## Summary
Implements Phase A scaffolding for:
- #43 OP Stack consensus mode plumbing + feature-flag gate
- #44 Linea consensus mode plumbing + feature-flag gate parity
- #45 Desktop simulation replay command skeleton + deterministic reason surface

## What changed
- Added `enableExperimentalOpstackConsensus` rollout option in core consensus fetch path and gated OP Stack envelopes behind it (matching Linea gating behavior).
- Updated CLI analyze flow:
  - new flag: `--enable-experimental-opstack-consensus`
  - continues to support `--enable-experimental-linea-consensus`
- Updated generator analyze flow:
  - new env gate: `NEXT_PUBLIC_ENABLE_OPSTACK_CONSENSUS=1`
  - existing Linea env gate remains in place.
- Added desktop Tauri command skeleton:
  - `verify_simulation_replay` with typed request/response contracts
  - wired command registration in `main.rs`
  - added `revm` dependency for upcoming replay implementation.
- Added core replay result plumbing:
  - `SimulationReplayVerificationResult`
  - `applySimulationReplayVerificationToReport(...)`
  - deterministic simulation reason now includes `simulation-replay-exec-error`.
- Wired desktop verification hook to invoke replay command and feed result into core report/sources.

## Trust behavior
- Unchanged in this phase: simulation trust stays `rpc-sourced`.
- Replay skeleton returns deterministic `simulation-replay-not-run`.
- Invoke/runtime failures surface deterministic `simulation-replay-exec-error`.

## Validation
- `bun run type-check`
- `bun --cwd packages/core test src/lib/consensus/__tests__/index.test.ts`
- `bun --cwd packages/core test src/lib/trust/__tests__/sources.test.ts`
- `bun --cwd packages/core test src/lib/verify/__tests__/simulation-witness.test.ts`
- `bun --cwd packages/cli test src/cli.output.test.ts`
- `cargo check` in `apps/desktop/src-tauri`

Closes #43
Closes #44
Closes #45

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-proof routing and introduces new feature-flagged paths that could change which chains attempt consensus fetching. Desktop replay is currently a stub, but it adds new cross-layer plumbing and new failure modes in verification reporting.
> 
> **Overview**
> Adds an explicit `enableExperimentalOpstackConsensus` rollout gate to `fetchConsensusProof`, rejecting OP Stack envelope fetching by default (mirroring existing Linea gating), and wires this through the generator (new `NEXT_PUBLIC_ENABLE_OPSTACK_CONSENSUS`) and CLI (new `--enable-experimental-opstack-consensus`) with updated tests.
> 
> Introduces a desktop Tauri `verify_simulation_replay` command (plus `revm` dependency) as a Phase A skeleton that returns deterministic "not run" results, and threads a new `SimulationReplayVerificationResult` through core verification/reporting so the UI can surface deterministic reasons including `simulation-replay-exec-error` when the invoke fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9d61e1500260c8198d8c15b81ebed3151d1aa22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->