### PR TITLE
Rollout OP Stack/Linea consensus by default + Bugbot fixes

### DIFF
--- a/apps/generator/app/page.tsx
+++ b/apps/generator/app/page.tsx
@@ -34,8 +34,8 @@ import { AddressDisplay } from "@/components/address-display";
 import type { EvidencePackage, SafeTransaction } from "@safelens/core";
 
 const generationSources = buildGenerationSources();
-const opstackConsensusEnabled = process.env.NEXT_PUBLIC_ENABLE_OPSTACK_CONSENSUS === "1";
-const lineaConsensusEnabled = process.env.NEXT_PUBLIC_ENABLE_LINEA_CONSENSUS === "1";
+const opstackConsensusEnabled = process.env.NEXT_PUBLIC_ENABLE_OPSTACK_CONSENSUS !== "0";
+const lineaConsensusEnabled = process.env.NEXT_PUBLIC_ENABLE_LINEA_CONSENSUS !== "0";
 const RPC_PING_TIMEOUT_MS = 3500;
 const DEFAULT_RPC_CANDIDATES: Record<number, [string, string]> = {
   1: ["https://eth.drpc.org", "https://eth1.lava.build"],

--- a/packages/cli/src/cli.output.test.ts
+++ b/packages/cli/src/cli.output.test.ts
@@ -316,10 +316,10 @@ describe("CLI verify output", () => {
     expect(result.stderr).toContain("Invalid JSON format");
   });
 
-  it("documents experimental consensus analyze flags in help output", () => {
+  it("documents consensus rollout override flags in help output", () => {
     const result = runCli([]);
     expect(result.code).toBe(0);
-    expect(result.stdout).toContain("--enable-experimental-opstack-consensus");
-    expect(result.stdout).toContain("--enable-experimental-linea-consensus");
+    expect(result.stdout).toContain("--disable-opstack-consensus");
+    expect(result.stdout).toContain("--disable-linea-consensus");
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -67,8 +67,8 @@ Usage:
 
 Options:
   --rpc-url <url>   Fetch on-chain policy proof + simulate transaction via RPC
-  --enable-experimental-opstack-consensus  Enable experimental OP Stack consensus envelope fetch in analyze
-  --enable-experimental-linea-consensus  Enable experimental Linea consensus envelope fetch in analyze
+  --disable-opstack-consensus  Disable OP Stack consensus envelope fetch in analyze
+  --disable-linea-consensus  Disable Linea consensus envelope fetch in analyze
 
 Examples:
   safelens analyze "https://app.safe.global/transactions/tx?safe=eth:0x...&id=multisig_..." --out evidence.json
@@ -432,8 +432,8 @@ async function runAnalyze(args: string[]) {
   const format = getOutputFormat(args, "text");
 
   const rpcUrl = getFlag(args, "--rpc-url");
-  const enableExperimentalOpstackConsensus = hasFlag(args, "--enable-experimental-opstack-consensus");
-  const enableExperimentalLineaConsensus = hasFlag(args, "--enable-experimental-linea-consensus");
+  const disableOpstackConsensus = hasFlag(args, "--disable-opstack-consensus");
+  const disableLineaConsensus = hasFlag(args, "--disable-linea-consensus");
 
   const parsed = parseSafeUrlFlexible(url);
 
@@ -476,11 +476,11 @@ async function runAnalyze(args: string[]) {
       if ((consensusMode === "opstack" || consensusMode === "linea") && rpcUrl) {
         consensusOptions.rpcUrl = rpcUrl;
       }
-      if (enableExperimentalOpstackConsensus) {
-        consensusOptions.enableExperimentalOpstackConsensus = true;
+      if (disableOpstackConsensus) {
+        consensusOptions.enableExperimentalOpstackConsensus = false;
       }
-      if (enableExperimentalLineaConsensus) {
-        consensusOptions.enableExperimentalLineaConsensus = true;
+      if (disableLineaConsensus) {
+        consensusOptions.enableExperimentalLineaConsensus = false;
       }
       evidence = await enrichWithConsensusProof(evidence, consensusOptions);
     } catch (err) {

--- a/packages/core/src/lib/consensus/__tests__/index.test.ts
+++ b/packages/core/src/lib/consensus/__tests__/index.test.ts
@@ -52,7 +52,6 @@ describe("consensus mode routing", () => {
     const proof = await fetchConsensusProof(10, {
       rpcUrl: "https://example.invalid/rpc",
       blockTag: "finalized",
-      enableExperimentalOpstackConsensus: true,
     });
 
     expect(proof).toMatchObject({
@@ -86,7 +85,6 @@ describe("consensus mode routing", () => {
     const proof = await fetchConsensusProof(8453, {
       rpcUrl: "https://example.invalid/rpc",
       blockTag: "finalized",
-      enableExperimentalOpstackConsensus: true,
     });
 
     expect(proof).toMatchObject({
@@ -112,7 +110,6 @@ describe("consensus mode routing", () => {
 
     const proof = await fetchConsensusProof(59144, {
       rpcUrl: "https://example.invalid/rpc",
-      enableExperimentalLineaConsensus: true,
     });
 
     expect(proof).toMatchObject({
@@ -125,16 +122,24 @@ describe("consensus mode routing", () => {
     expect("proofPayload" in proof).toBe(true);
   });
 
-  it("rejects opstack envelopes when rollout feature flag is disabled", async () => {
-    await expect(fetchConsensusProof(10)).rejects.toMatchObject({
+  it("rejects opstack envelopes when rollout override disables the mode", async () => {
+    await expect(
+      fetchConsensusProof(10, {
+        enableExperimentalOpstackConsensus: false,
+      })
+    ).rejects.toMatchObject({
       code: UNSUPPORTED_CONSENSUS_MODE_ERROR_CODE,
       consensusMode: "opstack",
       reason: "disabled-by-feature-flag",
     });
   });
 
-  it("rejects linea envelopes when rollout feature flag is disabled", async () => {
-    await expect(fetchConsensusProof(59144)).rejects.toMatchObject({
+  it("rejects linea envelopes when rollout override disables the mode", async () => {
+    await expect(
+      fetchConsensusProof(59144, {
+        enableExperimentalLineaConsensus: false,
+      })
+    ).rejects.toMatchObject({
       code: UNSUPPORTED_CONSENSUS_MODE_ERROR_CODE,
       consensusMode: "linea",
       reason: "disabled-by-feature-flag",
@@ -152,7 +157,6 @@ describe("consensus mode routing", () => {
       fetchConsensusProof(10, {
         rpcUrl: "https://example.invalid/rpc",
         blockTag: "latest",
-        enableExperimentalOpstackConsensus: true,
       })
     ).rejects.toThrow(
       "Execution consensus envelopes require blockTag='finalized'; received 'latest'."
@@ -164,7 +168,6 @@ describe("consensus mode routing", () => {
       fetchConsensusProof(59144, {
         rpcUrl: "https://example.invalid/rpc",
         blockTag: "safe",
-        enableExperimentalLineaConsensus: true,
       })
     ).rejects.toThrow(
       "Execution consensus envelopes require blockTag='finalized'; received 'safe'."

--- a/packages/core/src/lib/consensus/index.ts
+++ b/packages/core/src/lib/consensus/index.ts
@@ -24,13 +24,13 @@ export interface FetchConsensusProofOptions
   extends BeaconFetchConsensusProofOptions,
     FetchExecutionConsensusProofOptions {
   /**
-   * Rollout gate for experimental OP Stack consensus envelopes.
-   * Default is false until verifier/runtime hardening is complete.
+   * Optional rollout override for OP Stack consensus envelopes.
+   * Defaults to enabled; set to false only for emergency rollback.
    */
   enableExperimentalOpstackConsensus?: boolean;
   /**
-   * Rollout gate for experimental Linea consensus envelopes.
-   * Default is false until the full verifier path is complete.
+   * Optional rollout override for Linea consensus envelopes.
+   * Defaults to enabled; set to false only for emergency rollback.
    */
   enableExperimentalLineaConsensus?: boolean;
 }
@@ -59,7 +59,7 @@ export class UnsupportedConsensusModeError extends Error {
  * Fetch a consensus proof for a chain using explicit mode routing.
  * Beacon uses light-client proofs; opstack/linea return execution-header
  * proof envelopes for packaging. Desktop verification runs deterministic
- * envelope checks for those modes and emits explicit pending-verifier codes.
+ * envelope checks for those modes.
  */
 export async function fetchConsensusProof(
   chainId: number,
@@ -79,7 +79,7 @@ export async function fetchConsensusProof(
 
   if (
     capability.consensusMode === "opstack" &&
-    options.enableExperimentalOpstackConsensus !== true
+    options.enableExperimentalOpstackConsensus === false
   ) {
     throw new UnsupportedConsensusModeError(
       chainId,
@@ -90,7 +90,7 @@ export async function fetchConsensusProof(
 
   if (
     capability.consensusMode === "linea" &&
-    options.enableExperimentalLineaConsensus !== true
+    options.enableExperimentalLineaConsensus === false
   ) {
     throw new UnsupportedConsensusModeError(
       chainId,

--- a/packages/core/src/lib/verify/index.ts
+++ b/packages/core/src/lib/verify/index.ts
@@ -259,10 +259,7 @@ function buildReportSources(
           : options.simulationReplayVerification?.reason ===
               "simulation-replay-exec-error"
             ? "simulation-replay-exec-error"
-            : options.simulationReplayVerification?.reason ===
-                "simulation-replay-not-run"
-              ? "simulation-replay-not-run"
-              : "simulation-replay-not-run";
+            : "simulation-replay-not-run";
   const decodedSteps = options.evidence.dataDecoded
     ? normalizeCallSteps(
         options.evidence.dataDecoded,


### PR DESCRIPTION
## Summary
- resolves the two Bugbot findings from #47 in follow-up code
- completes OP Stack/Linea rollout defaults so consensus envelopes are enabled by default (with explicit disable override)
- updates CLI and tests to match non-experimental rollout semantics

## Changes
- 
  - run simulation replay whenever simulation+witness exist, even if no consensus proof is present
- 
  - simplify redundant replay reason ternary
- 
  - flip OP Stack/Linea rollout gate semantics from opt-in to enabled-by-default, keep explicit disable override
- 
  - default OP Stack/Linea consensus enrichment to enabled unless env explicitly sets 
- 
  - replace experimental opt-in flags with rollout override flags:
    - 
    - 
- updated tests:
  - 
  - 

## Validation
- 
 RUN  v4.0.18 /workspaces/mission-ca5bbb82/SafeLens/packages/core

 ✓ src/lib/consensus/__tests__/index.test.ts (10 tests) 59ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  18:33:17
   Duration  425ms (transform 90ms, setup 49ms, import 79ms, tests 59ms, environment 0ms)
- 
 RUN  v4.0.18 /workspaces/mission-ca5bbb82/SafeLens/packages/core

 ✓ src/lib/verify/__tests__/simulation-witness.test.ts (4 tests) 73ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  18:33:18
   Duration  1.22s (transform 347ms, setup 47ms, import 870ms, tests 73ms, environment 0ms)
- 
 RUN  v4.0.18 /workspaces/mission-ca5bbb82/SafeLens/packages/core

 ✓ src/lib/trust/__tests__/sources.test.ts (21 tests) 16ms

 Test Files  1 passed (1)
      Tests  21 passed (21)
   Start at  18:33:20
   Duration  1.42s (transform 444ms, setup 67ms, import 1.04s, tests 16ms, environment 0ms)
- bun test v1.3.9 (cf6cdbbb)
- 
- 
- 

Closes #19
Closes #20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default behavior for consensus proof fetching and verification ordering, which can affect evidence generation/verification outputs and trust decisions across multiple entrypoints; however the changes are mostly flag semantics and flow reordering with test updates.
> 
> **Overview**
> Enables OP Stack and Linea consensus envelope fetching *by default* across generator/CLI/core, switching rollout semantics from opt-in to enabled-unless-explicitly-disabled.
> 
> Fixes desktop verification flow to run simulation replay verification whenever `simulation` + `simulationWitness` exist (even if no `consensusProof`), then applies consensus verification afterward when present. Updates CLI help/tests and core consensus routing/tests to reflect the new `--disable-*-consensus` overrides and the new default-enabled behavior, plus a small simplification of simulation replay reason handling in `verify`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ddb08b5b1d042169549c9493a2941f98bb670df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->