### PR TITLE
fix(core): preserve replay witness fields for local simulation replay

### DIFF
--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -247,6 +247,17 @@ export const simulationWitnessSchema = z.object({
     })
   ),
   simulationDigest: hashSchema,
+  replayAccounts: z.array(
+    z.object({
+      address: addressSchema,
+      balance: z.string(),
+      nonce: z.number().int().nonnegative(),
+      code: hexDataSchema,
+      storage: z.record(storageSlotKeySchema, storageValueSchema).default({}),
+    })
+  ).optional(),
+  replayCaller: addressSchema.optional(),
+  replayGasLimit: z.number().int().positive().optional(),
 });
 
 export type SimulationWitness = z.infer<typeof simulationWitnessSchema>;


### PR DESCRIPTION
## Summary
- fix `simulationWitness` schema to include replay-world-state fields used by desktop Tauri replay verification:
  - `replayAccounts`
  - `replayCaller`
  - `replayGasLimit`
- add regression coverage proving those fields survive schema parsing instead of being stripped

## Why
Phase B replay verification consumes replay witness fields in desktop (`verify_simulation_replay`).
Before this change, core schema parsing dropped those unknown fields, causing replay to see an incomplete witness and preventing intended replay verification flow.

## Validation
- `bun --cwd packages/core test src/lib/package/__tests__/schema-extensions.test.ts`
- `bun --cwd packages/core test src/lib/verify/__tests__/simulation-witness.test.ts`
- `bun --cwd packages/core test src/lib/trust/__tests__/sources.test.ts`
- `bun --cwd packages/core type-check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema change is additive (optional fields) and covered by a targeted regression test; minimal blast radius beyond validation/serialization behavior.
> 
> **Overview**
> Fixes `simulationWitnessSchema` to explicitly accept and validate replay replay-world-state fields used for local simulation replay: `replayAccounts` (including per-account `storage`), `replayCaller`, and `replayGasLimit`.
> 
> Adds a regression test in `schema-extensions.test.ts` that parses a witness containing these fields and asserts they are preserved in the parsed output (not stripped).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 895f1c5512c2d1fddce546d6cc1df3635efa36ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->