### PR TITLE
fix: harden replay quantity validation and schema consistency

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "macos")]
 use tauri::Manager;
 
 mod consensus;
@@ -26,13 +27,17 @@ fn main() {
             verify_simulation_replay
         ])
         .setup(|app| {
-            let window = app.get_webview_window("main").unwrap();
-
             #[cfg(target_os = "macos")]
             {
+                let window = app.get_webview_window("main").unwrap();
                 use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
                 apply_vibrancy(&window, NSVisualEffectMaterial::Sidebar, None, None)
                     .expect("failed to apply vibrancy");
+            }
+
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = app;
             }
 
             Ok(())

--- a/packages/core/src/lib/package/__tests__/schema-extensions.test.ts
+++ b/packages/core/src/lib/package/__tests__/schema-extensions.test.ts
@@ -501,6 +501,11 @@ describe("simulation schema", () => {
     expect(simulationSchema.safeParse(invalid).success).toBe(false);
   });
 
+  it("rejects simulation with invalid gas quantity", () => {
+    const invalid = { ...MOCK_SIMULATION, gasUsed: "not-a-quantity" };
+    expect(simulationSchema.safeParse(invalid).success).toBe(false);
+  });
+
   it("validates simulation log structure", () => {
     const result = simulationSchema.safeParse(MOCK_SIMULATION);
     expect(result.success).toBe(true);
@@ -557,5 +562,30 @@ describe("simulation witness schema", () => {
       expect(result.data.replayCaller).toBe(witness.replayCaller);
       expect(result.data.replayGasLimit).toBe(3000000);
     }
+  });
+
+  it("rejects replay account balances that are not numeric quantities", () => {
+    const witness = {
+      chainId: 1,
+      safeAddress: "0x9fC3dc011b461664c835F2527fffb1169b3C213e",
+      blockNumber: 19000000,
+      stateRoot:
+        "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
+      safeAccountProof: MOCK_POLICY_PROOF.accountProof,
+      overriddenSlots: [],
+      simulationDigest:
+        "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      replayAccounts: [
+        {
+          address: "0x9fC3dc011b461664c835F2527fffb1169b3C213e",
+          balance: "one-eth",
+          nonce: 0,
+          code: "0x",
+          storage: {},
+        },
+      ],
+    };
+
+    expect(simulationWitnessSchema.safeParse(witness).success).toBe(false);
   });
 });

--- a/packages/core/src/lib/simulation/__tests__/verifier.test.ts
+++ b/packages/core/src/lib/simulation/__tests__/verifier.test.ts
@@ -78,6 +78,20 @@ describe("verifySimulation", () => {
     expect(check?.passed).toBe(true);
   });
 
+  it("passes for hex gas quantity", () => {
+    const result = verifySimulation(makeValidSimulation({ gasUsed: "0x5208" }));
+    expect(result.valid).toBe(true);
+    const check = result.checks.find((c) => c.id === "gas-used");
+    expect(check?.passed).toBe(true);
+  });
+
+  it("fails for malformed hex gas quantity", () => {
+    const result = verifySimulation(makeValidSimulation({ gasUsed: "0x" }));
+    expect(result.valid).toBe(false);
+    const check = result.checks.find((c) => c.id === "gas-used");
+    expect(check?.passed).toBe(false);
+  });
+
   it("fails for invalid returnData hex", () => {
     const result = verifySimulation(
       makeValidSimulation({ returnData: "invalid-hex" as `0x${string}` })

--- a/packages/core/src/lib/simulation/verifier.ts
+++ b/packages/core/src/lib/simulation/verifier.ts
@@ -23,12 +23,23 @@ export interface SimulationVerificationResult {
   checks: SimulationCheck[];
 }
 
+function parseEvmQuantity(raw: string): bigint | null {
+  if (!/^(?:0[xX][0-9a-fA-F]+|[0-9]+)$/.test(raw)) {
+    return null;
+  }
+  try {
+    return BigInt(raw);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Verify structural consistency of a simulation result.
  *
  * Checks:
  * 1. Block number is a positive integer
- * 2. Gas used is a non-negative decimal string
+ * 2. Gas used is a non-negative numeric quantity string (decimal or hex)
  * 3. Return data is valid hex (or null)
  * 4. All logs have valid structure
  * 5. All state diffs have valid structure (if present)
@@ -56,8 +67,8 @@ export function verifySimulation(
   }
 
   // 2. Gas used
-  const gasNum = Number(simulation.gasUsed);
-  const gasValid = !isNaN(gasNum) && gasNum >= 0;
+  const gasValue = parseEvmQuantity(simulation.gasUsed);
+  const gasValid = gasValue !== null && gasValue >= 0n;
   checks.push({
     id: "gas-used",
     label: "Gas used",


### PR DESCRIPTION
## Summary
This is a follow-up hardening pass after reviewing merged PRs #51 and #50.

### Fixed issues
1. Tightened schema validation for replay-critical numeric fields so malformed packages fail at parse time instead of during desktop replay:
- Added shared `evmQuantitySchema` (decimal or `0x`/`0X` hex quantity).
- Applied it to:
  - `simulationWitness.replayAccounts[*].balance`
  - `simulation.gasUsed`
  - `safeTransaction.value`, `safeTransaction.safeTxGas`, `safeTransaction.baseGas`, `safeTransaction.gasPrice`
  - `evidencePackage.transaction.value`, `safeTxGas`, `baseGas`, `gasPrice`
  - `onchainPolicyProof.accountProof.balance`

2. Updated simulation structural verifier to parse gas as EVM quantity (`BigInt`) instead of `Number(...)`, which is stricter and avoids precision/range issues.

3. Added/updated regression tests:
- Reject invalid simulation gas quantity in schema tests.
- Reject invalid replay account balance quantity in witness schema tests.
- Verify simulation verifier behavior for hex gas quantities and malformed hex quantity.

4. Cleaned maintainability issue in desktop Tauri entrypoint:
- Removed non-macOS unused-variable warning in `main.rs` by making `window` and `Manager` usage platform-conditional.

## Why
PR #51 and #50 introduced replay-complete witness flow, but several numeric strings were still permissive at schema boundaries. Tightening these fields improves auditability and fails closed earlier.

## Validation
- `bun --cwd packages/core test`
- `bun --cwd packages/core type-check`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml simulation_replay::tests::`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml simulation_replay::tests::returns_success_when_replay_matches_simulation`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema tightening and stricter gas parsing may reject previously accepted packages/inputs, affecting compatibility at parse/verification boundaries. Changes are localized and covered by new regression tests, but touch cross-package data contracts.
> 
> **Overview**
> Tightens validation of replay-critical numeric strings by introducing `evmQuantitySchema` (decimal or `0x`/`0X` hex) and applying it to `simulation.gasUsed`, replay witness account balances, `accountProof.balance`, and Safe/evidence-package transaction gas/value fields.
> 
> Updates `verifySimulation` to parse `gasUsed` as an EVM quantity via `BigInt` (instead of `Number`) and adds tests covering invalid quantities plus valid/malformed hex gas values. Also makes the Tauri desktop `main.rs` vibrancy/window code macOS-only to avoid non-macOS unused-variable warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8ac24233533133e74788a7c93baad3ec59bdd05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->