### PR TITLE
fix: align quantity schema with replay parser

### DIFF
--- a/packages/core/src/lib/package/__tests__/schema-extensions.test.ts
+++ b/packages/core/src/lib/package/__tests__/schema-extensions.test.ts
@@ -506,6 +506,11 @@ describe("simulation schema", () => {
     expect(simulationSchema.safeParse(invalid).success).toBe(false);
   });
 
+  it("rejects simulation with uppercase-0X gas quantity", () => {
+    const invalid = { ...MOCK_SIMULATION, gasUsed: "0X5208" };
+    expect(simulationSchema.safeParse(invalid).success).toBe(false);
+  });
+
   it("validates simulation log structure", () => {
     const result = simulationSchema.safeParse(MOCK_SIMULATION);
     expect(result.success).toBe(true);
@@ -579,6 +584,31 @@ describe("simulation witness schema", () => {
         {
           address: "0x9fC3dc011b461664c835F2527fffb1169b3C213e",
           balance: "one-eth",
+          nonce: 0,
+          code: "0x",
+          storage: {},
+        },
+      ],
+    };
+
+    expect(simulationWitnessSchema.safeParse(witness).success).toBe(false);
+  });
+
+  it("rejects replay account balances with uppercase-0X prefix", () => {
+    const witness = {
+      chainId: 1,
+      safeAddress: "0x9fC3dc011b461664c835F2527fffb1169b3C213e",
+      blockNumber: 19000000,
+      stateRoot:
+        "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
+      safeAccountProof: MOCK_POLICY_PROOF.accountProof,
+      overriddenSlots: [],
+      simulationDigest:
+        "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      replayAccounts: [
+        {
+          address: "0x9fC3dc011b461664c835F2527fffb1169b3C213e",
+          balance: "0X1",
           nonce: 0,
           code: "0x",
           storage: {},

--- a/packages/core/src/lib/simulation/__tests__/verifier.test.ts
+++ b/packages/core/src/lib/simulation/__tests__/verifier.test.ts
@@ -85,6 +85,13 @@ describe("verifySimulation", () => {
     expect(check?.passed).toBe(true);
   });
 
+  it("fails for uppercase-0X hex gas quantity", () => {
+    const result = verifySimulation(makeValidSimulation({ gasUsed: "0X5208" }));
+    expect(result.valid).toBe(false);
+    const check = result.checks.find((c) => c.id === "gas-used");
+    expect(check?.passed).toBe(false);
+  });
+
   it("fails for malformed hex gas quantity", () => {
     const result = verifySimulation(makeValidSimulation({ gasUsed: "0x" }));
     expect(result.valid).toBe(false);

--- a/packages/core/src/lib/simulation/verifier.ts
+++ b/packages/core/src/lib/simulation/verifier.ts
@@ -6,7 +6,7 @@
  * when a replay-complete simulation witness is present.
  */
 
-import type { Simulation } from "../types";
+import { evmQuantitySchema, type Simulation } from "../types";
 
 export interface SimulationCheck {
   id: string;
@@ -24,7 +24,7 @@ export interface SimulationVerificationResult {
 }
 
 function parseEvmQuantity(raw: string): bigint | null {
-  if (!/^(?:0[xX][0-9a-fA-F]+|[0-9]+)$/.test(raw)) {
+  if (!evmQuantitySchema.safeParse(raw).success) {
     return null;
   }
   try {

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -17,10 +17,10 @@ export const hexDataSchema = z
   .regex(/^0x[a-fA-F0-9]*$/, "Invalid hex data");
 
 // EVM quantity-like numeric string accepted across package boundaries.
-// Supports decimal ("21000") and hex ("0x5208"/"0X5208").
+// Supports decimal ("21000") and lowercase-prefixed hex ("0x5208").
 export const evmQuantitySchema = z
   .string()
-  .regex(/^(?:0[xX][a-fA-F0-9]+|[0-9]+)$/, "Invalid numeric quantity");
+  .regex(/^(?:0x[a-fA-F0-9]+|[0-9]+)$/, "Invalid numeric quantity");
 
 // Storage slot keys from eth_getProof may be compact quantities (e.g. 0x0)
 // or fully padded 32-byte words.


### PR DESCRIPTION
## Summary
- make evmQuantitySchema match desktop replay parsing by accepting decimal or 0x hex (reject 0X)
- remove duplicated quantity regex in simulation verifier by reusing the shared schema
- add regression tests for uppercase 0X rejection in simulation schema, witness schema, and simulation verifier

## Why
Desktop replay parses hex values with a lowercase 0x prefix. Allowing 0X at the schema boundary lets malformed packages pass validation and fail later at replay time.

## Validation
- bun --cwd packages/core test
- bun --cwd packages/core type-check
- bun run test
- bun run type-check