### PR TITLE
ci: enforce workspace type-check before tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,24 @@ on:
     branches: [main]
 
 jobs:
+  type-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: TypeScript type-check
+        run: bun run type-check
+
   test:
     runs-on: ubuntu-latest
+    needs: type-check
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add a dedicated `type-check` job to `.github/workflows/test.yml`
- run `bun run type-check` for the full workspace in CI
- gate the existing `test` job behind `needs: type-check`

## Why
Current CI can pass tests while still allowing TypeScript regressions to merge. This change enforces compile-time validation before test execution.

## Validation
- `bun run type-check` (local) ✅

Closes #70

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change that gates tests on a TypeScript type-check; primary risk is longer or more brittle CI due to an additional job.
> 
> **Overview**
> Adds a new GitHub Actions `type-check` job that installs dependencies with Bun and runs `bun run type-check`.
> 
> Updates the existing `test` job to **require** `type-check` via `needs: type-check`, ensuring TypeScript type errors fail CI before any package/app tests run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c7a1a52872ea84f91919e38c121f41e8ff6a7d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->