### PR TITLE
ci: enforce lint before test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,21 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Workspace lint
+        run: bun run lint
+
   type-check:
     runs-on: ubuntu-latest
 
@@ -24,7 +39,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: type-check
+    needs: [lint, type-check]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add a dedicated `lint` CI job in `.github/workflows/test.yml`
- make the `test` job depend on both `lint` and `type-check`
- keep existing test matrix unchanged

## Why
Type-check + tests alone can miss lint/static-analysis regressions in the generator app. This makes lint a required precondition before test execution.

Closes #72

## Validation
- `bun run lint`
- `bun run type-check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that just adds an extra lint gate before running tests; no runtime or production code is modified.
> 
> **Overview**
> Adds a dedicated **CI `lint` job** to `.github/workflows/test.yml` that runs `bun run lint` after installing dependencies.
> 
> Updates the `test` job to **depend on both `lint` and `type-check`**, so tests only run if linting and TypeScript checks pass.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6036365aac910620a9c5f566aa5ee170afc8d9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->