### PR TITLE
ci: run desktop Rust unit tests in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,15 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: './apps/desktop/src-tauri -> target'


### PR DESCRIPTION
## Summary
- add a dedicated `rust-test` job in `.github/workflows/test.yml`
- run `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` in PR CI
- require `rust-test` before the existing workspace test job runs

## Why
The desktop Tauri crate has Rust unit tests that were not executed in the test workflow, so Rust regressions could merge undetected.

## Validation
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml -q`

Closes #74

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only changes that add an extra job and dependency installs; main impact is longer/more failure-prone workflow runs due to Linux package/Rust setup.
> 
> **Overview**
> Adds a dedicated `rust-test` job to `.github/workflows/test.yml` that installs Rust + required Linux deps, uses `rust-cache`, and runs `cargo test` for the Tauri desktop crate (`apps/desktop/src-tauri`).
> 
> Updates the existing `test` job to depend on `rust-test`, ensuring Rust unit tests pass before the Bun-based workspace tests run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b1b230ab95e0e8a12502c710a96763f11cefa8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->