### PR TITLE
ci: enforce workspace production build in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,3 +85,19 @@ jobs:
 
       - name: Desktop tests
         run: bun run --cwd apps/desktop test
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [test]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Workspace production build
+        run: bun run build


### PR DESCRIPTION
## Summary
- add a new `build` job to `.github/workflows/test.yml`
- run `bun run build` in CI to validate production builds for Generator + Desktop UI
- make `build` depend on `test` so build runs after existing quality gates

## Why
CI currently allows merges where tests pass but production build output is broken.

## Validation
- `bun run build`

Closes #76

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change that adds an extra build gate; main risk is increased CI time or build failures due to environment differences.
> 
> **Overview**
> Adds a new GitHub Actions `build` job that runs `bun run build` to validate the monorepo’s production build output in CI.
> 
> The `build` job depends on the existing `test` job, so builds only run after linting, type-checking, Rust tests, and JS/TS tests pass.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae2bdcc973957df78360c21015e906525670504d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->