### PR TITLE
ci: cancel superseded test runs and add job timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +29,7 @@ jobs:
 
   type-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +45,7 @@ jobs:
 
   rust-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -64,6 +71,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: [lint, type-check, rust-test]
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v4
@@ -89,6 +97,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [test]
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add workflow-level concurrency to cancel superseded in-progress `Tests` runs per PR/branch
- add explicit `timeout-minutes` to each CI job to prevent hangs consuming runners indefinitely

## Why
This improves CI signal quality and reduces wasted GitHub Actions minutes on stale runs after force-pushes or commit churn.

Closes #80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only configuration changes; main risk is inadvertently cancelling desired parallel runs or setting timeouts too low, causing flaky failures.
> 
> **Overview**
> Adds workflow-level `concurrency` to the `Tests` GitHub Actions workflow so newer pushes/PR updates cancel any in-progress runs for the same PR/branch.
> 
> Adds explicit `timeout-minutes` to each job (`lint`, `type-check`, `rust-test`, `test`, `build`) to prevent indefinite hangs and cap runner usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb0d5a9627af8ac4b0da2909acda3aaf5319d1d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->