### PR TITLE
ci: enforce rustfmt in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,21 @@ jobs:
       - name: TypeScript type-check
         run: bun run type-check
 
+  rust-fmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust formatting check
+        run: cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check
+
   rust-test:
     runs-on: ubuntu-latest
+    needs: [rust-fmt]
     timeout-minutes: 30
 
     steps:

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/apps/desktop/src-tauri/src/consensus.rs
+++ b/apps/desktop/src-tauri/src/consensus.rs
@@ -854,16 +854,14 @@ fn verify_execution_envelope(
     let packaged_at_raw =
         match input.package_packaged_at.as_deref() {
             Some(packaged_at) => packaged_at,
-            None => {
-                return fail_result_with_context(
-                    ERR_INVALID_PROOF_PAYLOAD,
-                    "packagePackagedAt is required for non-beacon consensus envelope freshness checks."
-                        .into(),
-                    checks,
-                    envelope_state_root,
-                    envelope_block_number,
-                )
-            }
+            None => return fail_result_with_context(
+                ERR_INVALID_PROOF_PAYLOAD,
+                "packagePackagedAt is required for non-beacon consensus envelope freshness checks."
+                    .into(),
+                checks,
+                envelope_state_root,
+                envelope_block_number,
+            ),
         };
     let packaged_at = match parse_rfc3339_timestamp(packaged_at_raw, "packagePackagedAt") {
         Ok(timestamp) => timestamp,
@@ -1345,8 +1343,8 @@ mod tests {
         expected_current_slot_for_network, get_network_config, parse_b256, parse_network,
         verify_consensus_proof, ConsensusNetwork, ConsensusProofInput,
         ERR_ENVELOPE_BLOCK_NUMBER_MISMATCH, ERR_ENVELOPE_NETWORK_MISMATCH,
-        ERR_ENVELOPE_STATE_ROOT_MISMATCH, ERR_INVALID_CHECKPOINT, ERR_INVALID_PROOF_PAYLOAD,
-        ERR_INVALID_EXPECTED_STATE_ROOT, ERR_NON_FINALIZED_CONSENSUS_ENVELOPE,
+        ERR_ENVELOPE_STATE_ROOT_MISMATCH, ERR_INVALID_CHECKPOINT, ERR_INVALID_EXPECTED_STATE_ROOT,
+        ERR_INVALID_PROOF_PAYLOAD, ERR_NON_FINALIZED_CONSENSUS_ENVELOPE,
         ERR_STALE_CONSENSUS_ENVELOPE, ERR_STATE_ROOT_MISMATCH, ERR_UNSUPPORTED_CONSENSUS_MODE,
         ERR_UNSUPPORTED_NETWORK,
     };


### PR DESCRIPTION
## Summary
- add a dedicated `rust-fmt` job to `.github/workflows/test.yml`
- run `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check`
- require `rust-test` to wait for `rust-fmt`
- apply rustfmt normalization to current Rust files so the gate passes immediately

## Why
Rust formatting drift was not gated in CI, allowing style-only churn into main. This change fails fast and keeps PR diffs behavior-focused.

Closes #82

## Validation
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check`
- `cargo test --locked --manifest-path apps/desktop/src-tauri/Cargo.toml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only gate plus rustfmt normalization; no functional logic changes beyond whitespace/formatting.
> 
> **Overview**
> Adds a dedicated `rust-fmt` GitHub Actions job that runs `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check`, and makes `rust-test` depend on it so formatting issues fail fast.
> 
> Applies rustfmt-only formatting normalization in the Tauri Rust code (e.g., `build.rs`, `consensus.rs`) without changing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 689091fdc3653b8341fce54e35fa57a7f273fe0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->