### PR TITLE
ci: set least-privilege permissions for test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- set explicit least-privilege `GITHUB_TOKEN` permissions for the `Tests` workflow
- keep existing jobs and behavior unchanged

## Change
- add top-level permissions in `.github/workflows/test.yml`:
  - `contents: read`

## Why
The workflow previously relied on repository defaults for token scope. Declaring minimal required permissions in code improves CI security posture and keeps policy explicit/reviewable.

Closes #84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI configuration hardening change that only narrows token permissions and should not affect runtime behavior unless a job implicitly relied on broader scopes.
> 
> **Overview**
> Adds an explicit top-level `permissions` block to the `Tests` GitHub Actions workflow, restricting the `GITHUB_TOKEN` scope to **read-only** repository contents (`contents: read`).
> 
> This makes CI token permissions least-privilege and explicit, without changing the existing jobs or execution behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed64aedcc56639d556b9d6d1a8a7ca5c189b77da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->