### PR TITLE
ci: pin Bun version in CI and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.9
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-24.04'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.9
 
       - run: bun install --frozen-lockfile
 
@@ -39,7 +39,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.9
 
       - run: bun install --frozen-lockfile
 
@@ -94,7 +94,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.9
 
       - run: bun install --frozen-lockfile
 
@@ -120,7 +120,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.9
 
       - run: bun install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "safelens",
   "version": "0.4.0",
   "private": true,
+  "packageManager": "bun@1.3.9",
   "workspaces": [
     "apps/*",
     "packages/*"


### PR DESCRIPTION
## Summary
- pin Bun to `1.3.9` in test workflow jobs
- pin Bun to `1.3.9` in release workflow
- declare `packageManager: bun@1.3.9` in root `package.json`

## Why
Using `bun-version: latest` introduces avoidable CI/release flakiness when upstream Bun publishes breaking changes.

## Validation
- `bun run lint`
- `bun run type-check`

Closes #86

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI/release configuration-only change that pins toolchain versions to reduce flakiness. Main risk is unexpected incompatibility if the repo/lockfile assumes a different Bun version.
> 
> **Overview**
> Pins `oven-sh/setup-bun` from `latest` to **Bun `1.3.9`** in `test.yml` (lint/type-check/test/build jobs) and `release.yml` to make CI and release builds reproducible.
> 
> Adds `packageManager: "bun@1.3.9"` to the root `package.json` to align local tooling with the CI version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2922b058de0a50911163aac1175d11c598d3a36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->