### PR TITLE
ci(release): scope write permissions and add concurrency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,11 @@ env:
   RUST_BACKTRACE: short
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -69,6 +73,8 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- set release workflow default token scope to read-only
- grant `contents: write` only to the `release` publishing job
- add release workflow concurrency to cancel superseded runs for the same ref

## Validation
- `bun run lint`

Closes #88

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow permissions and concurrency; main risk is unintended permission/concurrency behavior affecting release publishing.
> 
> **Overview**
> The release workflow now defaults `GITHUB_TOKEN` to **read-only** access and grants `contents: write` only to the `release` job that publishes the GitHub Release.
> 
> It also adds workflow-level `concurrency` keyed by workflow+ref to cancel in-progress runs when a newer run for the same tag/ref starts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cdec681123f52a71b509352ffa24ca6cf7917c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->