### PR TITLE
ci: add timeout bounds to release workflow jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +76,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary
Adds explicit timeout bounds to the release workflow so stuck release jobs fail predictably instead of consuming runner time indefinitely.

## Changes
- Add `timeout-minutes: 90` to the release `build` matrix job.
- Add `timeout-minutes: 20` to the `release` publishing job.

## Validation
- `bun run lint`

Closes #92

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that just bounds job runtime; the main risk is premature job failure if builds/releases occasionally exceed the new limits.
> 
> **Overview**
> Adds explicit `timeout-minutes` limits to the release GitHub Actions workflow so stuck jobs fail predictably.
> 
> The `build` matrix job now times out after 90 minutes, and the `release` publishing job times out after 20 minutes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ced520a522ca69fea77a5be83fabf2e294b779d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->