### PR TITLE
ci: add Dependabot config for actions, Bun deps, and Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:15"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      bun-workspace-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: "/apps/desktop/src-tauri"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:30"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - rust
+    groups:
+      tauri-rust-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
Adds repository-level Dependabot configuration to keep CI actions and runtime dependencies current with regular, grouped update PRs.

## Changes
- Added `.github/dependabot.yml` with weekly update schedules for:
  - `github-actions` in `/`
  - `npm` in `/` (Bun-managed workspace dependencies)
  - `cargo` in `/apps/desktop/src-tauri`
- Added grouping patterns to reduce PR noise.
- Added dependency labels by ecosystem.

## Validation
- `bun run lint`

Closes #96

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only Dependabot configuration with no runtime or production code changes; primary risk is increased CI/PR churn from automated updates.
> 
> **Overview**
> Adds a new repository-level `.github/dependabot.yml` to enable weekly Dependabot update PRs for **GitHub Actions**, **root npm/Bun workspace dependencies**, and **Tauri Cargo dependencies**.
> 
> Updates are grouped (one group per ecosystem), capped at 10 open PRs, and auto-labeled per ecosystem to reduce PR noise and improve triage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6578d2c578cac7950eee949d939d1ac3a2ad2f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->