### PR TITLE
docs: synchronize trust-boundary documentation with runtime behavior

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -23,7 +23,7 @@ User Input (Safe URL/address)
   → OPTIONAL: Enrich with on-chain policy proof via eth_getProof (rpc-sourced)
   → OPTIONAL: Enrich with simulation via eth_call + state overrides (rpc-sourced generation input)
   → OPTIONAL: Attach simulation witness (state root, account/storage proofs, replay world-state)
-  → If witness replay inputs are complete and operation is CALL (`operation=0`), export in witness-only simulation mode (packaged RPC effects retained; replay data attached for offline verification)
+  → If witness replay inputs are complete and operation is CALL (`operation=0`), export in witness-only simulation mode (simulation witness attached with replay inputs; packaged simulation effects retained for comparison against replay-derived effects)
   → OPTIONAL: Enrich with consensus proof (beacon BLS data or execution envelope)
   → Finalize export contract (fully-verifiable | partial)
   → Export JSON

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ SafeLens generates and verifies evidence packages for Gnosis Safe multisig trans
 
 ## Trust model
 
-The desktop verifier ships with `connect-src 'none'` CSP and no shell-open capability, it cannot make network requests during verification. All crypto runs locally using bundled libraries. See [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) for the full model.
+The desktop verifier ships with a CSP that restricts `connect-src` to Tauri IPC only (`ipc: http://ipc.localhost`) — no external network origins — and no shell-open capability. It cannot make network requests during verification. All crypto runs locally using bundled libraries. See [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) for the full model.
 
 ## Architecture and runbooks
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -39,13 +39,15 @@ as proof infrastructure is added.
 
 ## Evidence Package Sections
 
-The evidence package (v1.1) supports optional sections, each with an embedded trust classification:
+The evidence package schema accepts versions 1.0, 1.1, and 1.2, each with optional sections carrying an embedded trust classification:
 
 | Section | Trust field | Description |
 |---|---|---|
 | Core transaction data | - (always present) | EIP-712 fields, confirmations, hash, self-verified on parse |
 | `onchainPolicyProof` | `.trust` | Merkle storage proofs for Safe policy state (Phase 2) |
-| `simulation` | `.trust` | Transaction simulation result envelope (`success`, `returnData`, `gasUsed`, etc). In witness-only mode, effects/logs are derived at verify time from local replay. |
+| `simulation` | `.trust` | Transaction simulation result envelope (`success`, `returnData`, `gasUsed`, etc). When `simulationWitness.witnessOnly=true`, packaged simulation effects are retained for comparison but must be re-derived from local replay during verification. See [`docs/architecture/verification-source-contract.md`](docs/architecture/verification-source-contract.md) for the full witness-only verification matrix. |
+| `simulationWitness` | (implicit) | Replay inputs (world-state accounts, block environment) for offline simulation verification |
+| `consensusProof` | (implicit) | Beacon light client data or OP Stack/Linea execution envelope for consensus state-root verification (Phase 4) |
 
 Sections are independent and can be enabled progressively. A v1.0 package
 without these sections is fully supported and behaves identically to before.
@@ -64,7 +66,7 @@ From highest to lowest assurance:
 
 SafeLens desktop is intended to run in a fully airgapped environment after install:
 
-- Production CSP sets `connect-src 'none'`.
+- Production CSP sets `connect-src ipc: http://ipc.localhost` (Tauri IPC only, no external network origins).
 - No `shell-open` capability is enabled in Tauri allowlist or Rust features.
 - Desktop frontend source contains no network API calls.
 

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -171,7 +171,7 @@ export const stateDiffEntrySchema = z.object({
 export type StateDiffEntry = z.infer<typeof stateDiffEntrySchema>;
 
 const consensusProofBaseSchema = z.object({
-  /** Consensus verifier mode. Beacon is currently implemented in desktop verifier. */
+  /** Consensus verifier mode. Desktop verifier supports beacon (BLS), opstack, and linea (envelope checks). */
   consensusMode: consensusModeSchema.optional(),
   /** The EVM execution state root extracted from a finalized or verified execution payload. */
   stateRoot: hashSchema,
@@ -281,8 +281,10 @@ export const simulationWitnessSchema = z.object({
   ).optional(),
   replayCaller: addressSchema.optional(),
   replayGasLimit: z.number().int().positive().optional(),
-  /** When true, simulation effects (logs/nativeTransfers) are intentionally
-   * omitted from the packaged simulation and must be derived from local replay. */
+  /** When true, packaged simulation effects (logs/nativeTransfers) are retained
+   * but must be re-derived from local replay during verification. Set by the
+   * creator when witness contains complete replay inputs (world-state accounts
+   * + block environment) and operation is CALL (operation=0). */
   witnessOnly: z.boolean().optional(),
 });
 


### PR DESCRIPTION
## Summary

Batch fix for 9 documentation mismatch issues where trust-boundary docs had drifted from actual runtime behavior. These mismatches weaken auditor confidence in the documentation as a reliable entry point.

## Changes

| File | Fix |
|------|-----|
| `TRUST_ASSUMPTIONS.md` | Version pinning: `v1.1` → `v1.0/v1.1/v1.2` |
| `TRUST_ASSUMPTIONS.md` | Added missing `simulationWitness` and `consensusProof` rows to Evidence Package Sections table |
| `TRUST_ASSUMPTIONS.md` | Clarified witness-only simulation semantics with cross-reference to verification-source-contract.md |
| `TRUST_ASSUMPTIONS.md` | Fixed CSP claim: `connect-src 'none'` → `connect-src ipc: http://ipc.localhost` |
| `README.md` | Fixed CSP claim to match actual Tauri IPC-only policy |
| `AUDIT.md` | Clarified witness-only data flow description (effects retained for comparison, not derived-only) |
| `packages/core/src/lib/types.ts` | Updated `consensusMode` comment: "Beacon only" → "beacon/opstack/linea" |
| `packages/core/src/lib/types.ts` | Updated `witnessOnly` comment with when/why context |

## Test plan

- [x] `bun run type-check` passes (comments only in types.ts)
- [ ] CI passes

Closes #140, #133, #132, #131, #125, #123, #120, #119, #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/comment-only updates that clarify security/trust boundaries; no runtime logic changes, so functional risk is minimal aside from potential reader confusion if anything is misstated.
> 
> **Overview**
> Updates trust-boundary documentation to match current verifier/generator behavior, notably clarifying *witness-only* simulation semantics (packaged effects are retained for comparison but must be re-derived via local replay) and expanding the evidence schema version statement to include `1.0`/`1.1`/`1.2`.
> 
> Corrects the desktop airgap/CSP claim to reflect Tauri IPC-only `connect-src` (`ipc:`/`http://ipc.localhost`), adds missing `simulationWitness`/`consensusProof` section rows and references, and adjusts inline schema comments in `packages/core/src/lib/types.ts` to reflect supported consensus modes (beacon/opstack/linea) and when `simulationWitness.witnessOnly` is set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41e1693e8b5e5a42a8b8c938e7310bca1b675084. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->