### PR TITLE
fix: make consensusProof.finalizedSlot optional (informational metadata)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -177,7 +177,6 @@ Snapshot as of **2026-02-24** (synchronized with GitHub issue tracker):
 
 | Issue | Severity | Scope |
 |---|---|---|
-| #135 Trust-boundary mismatch: beacon `consensusProof.finalizedSlot` is schema-required but ignored by desktop verifier | Low | evidence contract drift: `finalizedSlot` appears authoritative in package schema but is not consumed/validated at desktop verification boundary (`packages/core`, `apps/desktop`) |
 | #134 Generator emits verbose evidence debug logs in production without opt-in | Low | production diagnostics trust boundary is always active and logs evidence metadata without explicit environment/user opt-in (`apps/generator`) |
 | #133 Docs mismatch: `AUDIT.md` witness-only simulation effects flow is stale | Low | auditor entry-point documentation drift: `AUDIT.md` still says witness-only effects are replay-derived while runtime keeps packaged simulation effects (`AUDIT.md`, `packages/core`) |
 | #132 Docs mismatch: `TRUST_ASSUMPTIONS` witness-only simulation effects contract is stale | Low | trust-boundary documentation drift in witness-only simulation semantics (`TRUST_ASSUMPTIONS.md`, `packages/core`) |
@@ -197,6 +196,7 @@ Snapshot as of **2026-02-24** (synchronized with GitHub issue tracker):
 
 | Issue | Resolution |
 |---|---|
+| #135 `consensusProof.finalizedSlot` is schema-required but ignored by desktop verifier | Fixed: `finalizedSlot` is now optional (`z.number().int().optional()`) with doc comment clarifying it is informational metadata not consumed by the desktop verifier |
 | #137 `simulationWitness.blockNumber` accepts non-integers | Fixed: schema now enforces `z.number().int()` |
 | #136 `simulationWitness.chainId` accepts non-integers | Fixed: schema now enforces `z.number().int()` |
 | #130 `simulation.blockNumber` accepts non-integers but desktop replay expects `u64` | Fixed: schema now enforces `z.number().int()` |

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -193,8 +193,8 @@ const beaconConsensusProofSchema = consensusProofBaseSchema.extend({
   finalityUpdate: z.string(),
   /** Beacon network identifier for selecting the correct fork config and genesis root. */
   network: z.enum(CONSENSUS_NETWORKS),
-  /** Beacon slot of the finalized header in the finality update. */
-  finalizedSlot: z.number(),
+  /** Beacon slot of the finalized header in the finality update. Informational metadata only — not consumed by the desktop verifier. */
+  finalizedSlot: z.number().int().optional(),
 });
 
 // Non-beacon proof envelope used by OP Stack and Linea integration paths.


### PR DESCRIPTION
## Summary

- Makes `consensusProof.finalizedSlot` optional in the beacon schema (`z.number().int().optional()`) — it is populated during generation but never consumed by the desktop verifier
- Adds `.int()` constraint consistent with the recent integer-schema hardening batch
- Updates doc comment to clarify this field is informational metadata, not a verification input
- Moves #135 from open to closed in AUDIT.md

## Context

Issue #135 identified a trust-boundary contract mismatch: `finalizedSlot` was schema-required (suggesting it's meaningful verification input), but the Rust `ConsensusProofInput` struct doesn't include it and Helios validates the finality update internally — only extracting the EVM execution state root and block number.

Making it optional aligns the schema with the actual verification boundary. Existing packages that include `finalizedSlot` still validate; new packages can omit it.

## Test plan

- [x] Type-check passes across all 4 packages
- [x] All 651 tests pass (545 core + 17 CLI + 89 desktop)
- [x] Existing test fixtures with `finalizedSlot: <number>` still validate (backwards compatible)

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema loosening for a field not consumed by verification; main risk is minor compatibility/validation behavior change for producers/consumers expecting it to be required.
> 
> **Overview**
> Aligns the evidence package schema with the desktop verification boundary by making `consensusProof.finalizedSlot` optional and explicitly *informational only* in the beacon consensus proof schema (now `z.number().int().optional()`).
> 
> Updates `AUDIT.md` to mark issue #135 as closed, reflecting the schema/documentation correction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6b8d0032c1f32e7442798c414011673fa67f241. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->