### PR TITLE
feat: surface state diff summaries in generator and desktop UIs

### DIFF
--- a/apps/generator/app/page.tsx
+++ b/apps/generator/app/page.tsx
@@ -21,6 +21,7 @@ import {
   decodeSimulationEvents,
   decodeNativeTransfers,
   computeRemainingApprovals,
+  summarizeStateDiffs,
   DEFAULT_SETTINGS_CONFIG,
   buildGenerationSources,
   getExportContractReasonLabel,
@@ -127,6 +128,7 @@ function EvidenceDisplay({
   const allEvents = [...nativeEvents, ...logEvents];
   const transfers = allEvents.filter((e) => e.kind !== "approval");
   const approvals = computeRemainingApprovals(allEvents);
+  const stateDiffSummary = summarizeStateDiffs(sim?.stateDiffs, allEvents, evidence.safeAddress);
 
   return (
     <Card>
@@ -221,6 +223,41 @@ function EvidenceDisplay({
                       </span>
                       <span className="text-amber-400/70">to</span>
                       <AddressDisplay address={a.spender} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {stateDiffSummary.totalSlotsChanged > 0 && (
+              <div className="rounded-md border border-blue-500/20 bg-blue-500/5 px-3 py-2">
+                <div className="text-xs font-medium text-blue-300">
+                  Storage changes
+                  <span className="ml-1.5 font-normal text-blue-400/70">
+                    {stateDiffSummary.totalSlotsChanged} slot{stateDiffSummary.totalSlotsChanged !== 1 ? "s" : ""} across {stateDiffSummary.contractsChanged} contract{stateDiffSummary.contractsChanged !== 1 ? "s" : ""}
+                  </span>
+                </div>
+                {stateDiffSummary.silentContracts > 0 && (
+                  <div className="mt-1 text-[11px] text-amber-400">
+                    {stateDiffSummary.silentContracts} contract{stateDiffSummary.silentContracts !== 1 ? "s" : ""} modified storage without emitting events — review state diffs for hidden effects.
+                  </div>
+                )}
+                <div className="mt-1.5 space-y-1">
+                  {stateDiffSummary.contracts.map((c) => (
+                    <div key={c.address} className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-blue-300/90">
+                      <AddressDisplay address={c.address} />
+                      <span className="text-blue-400/60">
+                        {c.slotsChanged} slot{c.slotsChanged !== 1 ? "s" : ""}
+                      </span>
+                      {c.tokenSymbol && (
+                        <span className="rounded bg-blue-500/10 px-1 py-0.5 text-[10px] font-medium text-blue-300">
+                          {c.tokenSymbol}
+                        </span>
+                      )}
+                      {!c.hasEvents && (
+                        <span className="rounded bg-amber-500/10 px-1 py-0.5 text-[10px] font-medium text-amber-400">
+                          no events
+                        </span>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/packages/core/src/lib/simulation/index.ts
+++ b/packages/core/src/lib/simulation/index.ts
@@ -27,7 +27,10 @@ export {
 export {
   summarizeSimulationEvents,
   computeRemainingApprovals,
+  summarizeStateDiffs,
   type SimulationEventsSummary,
   type SimulationTransferPreview,
   type RemainingApproval,
+  type StateDiffSummary,
+  type ContractStateDiff,
 } from "./summary";


### PR DESCRIPTION
## Summary

- Adds `summarizeStateDiffs()` in `packages/core/src/lib/simulation/summary.ts` that correlates prestateTracer storage diffs with decoded events, producing per-contract breakdowns
- Surfaces a new **"Storage changes"** panel in both generator and desktop UIs showing:
  - Total slots changed across N contracts
  - Per-contract slot count with resolved token symbol
  - **"no events" badge** on contracts that modified storage without emitting any decoded events (e.g. allowance consumed via `transferFrom`, direct storage writes via delegatecall)
  - **Warning** when silent contracts are detected, prompting users to review state diffs for hidden effects
- Adds 9 unit tests covering empty inputs, grouping, Safe exclusion, silent contract detection, symbol resolution, case-insensitive matching, and sort order

This is the next concrete step toward #105: it makes the existing `stateDiffs` data (populated by PR #149) visible to users, highlighting hidden state effects that event-only heuristics miss.

### Files changed
| File | Change |
|------|--------|
| `packages/core/src/lib/simulation/summary.ts` | New `summarizeStateDiffs()`, `StateDiffSummary`, `ContractStateDiff` types |
| `packages/core/src/lib/simulation/index.ts` | Export new function and types |
| `apps/generator/app/page.tsx` | Wire state diff display into Evidence panel |
| `apps/desktop/src/screens/VerifyScreen.tsx` | Wire state diff display into Verify panel |
| `packages/core/src/lib/simulation/__tests__/summary.test.ts` | 9 new tests |

## Test plan
- [x] All 565 vitest tests pass (core)
- [x] TypeScript type-check passes for core, generator, and desktop
- [ ] Verify storage changes panel renders correctly in generator when simulation includes stateDiffs
- [ ] Verify storage changes panel renders correctly in desktop when evidence includes stateDiffs
- [ ] Verify "no events" badge appears on contracts with silent storage changes
- [ ] Verify Safe address is excluded from the summary (since its storage changes are simulation artifacts)

Closes progress toward #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mainly UI additions, but introduces new logic that influences how simulation effects are interpreted and highlighted to users; incorrect correlation/exclusion could mislead reviewers about hidden state changes.
> 
> **Overview**
> Adds `summarizeStateDiffs` (plus `StateDiffSummary`/`ContractStateDiff` exports) to convert simulation `stateDiffs` into a per-contract summary, resolving token symbols from decoded events, sorting by slots changed, and flagging *silent* contracts that change storage without emitting events (excluding the Safe itself).
> 
> Updates both Generator and Desktop verification screens to compute this summary and render a new **Storage changes** panel showing total slot changes, per-contract breakdown, and a warning/badge when storage was modified with *no corresponding events*.
> 
> Extends core simulation summary tests with coverage for empty inputs, grouping/counting, Safe exclusion, silent-contract detection, symbol resolution, case-insensitive address matching, and sort order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4ef4f6066701487427349b4e0eeffaeef42040e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->