### PR TITLE
feat(core): ERC-20 storage slot decoder for proven approvals

### DIFF
--- a/apps/desktop/src/screens/VerifyScreen.tsx
+++ b/apps/desktop/src/screens/VerifyScreen.tsx
@@ -826,8 +826,8 @@ function ExecutionSafetyPanel({
     [decodedEvents],
   );
   const remainingApprovals = useMemo(
-    () => computeRemainingApprovals(decodedEvents),
-    [decodedEvents],
+    () => computeRemainingApprovals(decodedEvents, evidence.simulation?.stateDiffs),
+    [decodedEvents, evidence.simulation?.stateDiffs],
   );
   const stateDiffSummary = useMemo(
     () => summarizeStateDiffs(evidence.simulation?.stateDiffs, decodedEvents, evidence.safeAddress),

--- a/apps/generator/app/page.tsx
+++ b/apps/generator/app/page.tsx
@@ -127,7 +127,7 @@ function EvidenceDisplay({
     : [];
   const allEvents = [...nativeEvents, ...logEvents];
   const transfers = allEvents.filter((e) => e.kind !== "approval");
-  const approvals = computeRemainingApprovals(allEvents);
+  const approvals = computeRemainingApprovals(allEvents, sim?.stateDiffs);
   const stateDiffSummary = summarizeStateDiffs(sim?.stateDiffs, allEvents, evidence.safeAddress);
 
   return (

--- a/packages/core/src/lib/simulation/__tests__/slot-decoder.test.ts
+++ b/packages/core/src/lib/simulation/__tests__/slot-decoder.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeERC20StateDiffs,
+  __internal,
+} from "../slot-decoder";
+import type { StateDiffEntry } from "../../types";
+import type { DecodedEvent } from "../event-decoder";
+import {
+  keccak256,
+  encodeAbiParameters,
+  parseAbiParameters,
+  pad,
+  type Address,
+  type Hex,
+} from "viem";
+
+const SAFE = "0x1234567890abcdef1234567890abcdef12345678";
+const ALICE = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const BOB = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const SPENDER = "0xcccccccccccccccccccccccccccccccccccccccc";
+const DAI = "0x6b175474e89094c44da98b954eedeac495271d0f";
+const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+
+const ZERO = "0x" + "00".repeat(32);
+const abiParams = parseAbiParameters("address, uint256");
+
+function uint256Hex(n: bigint): Hex {
+  return pad(`0x${n.toString(16)}` as Hex, { size: 32 });
+}
+
+/** Compute mapping slot: keccak256(abi.encode(key, slot)) */
+function mappingSlot(key: Address, slot: bigint): Hex {
+  return keccak256(encodeAbiParameters(abiParams, [key, slot]));
+}
+
+/** Compute nested mapping slot for allowance(owner, spender, baseSlot) */
+function nestedMappingSlot(owner: Address, spender: Address, baseSlot: bigint): Hex {
+  const outerSlot = mappingSlot(owner, baseSlot);
+  return keccak256(encodeAbiParameters(abiParams, [spender, BigInt(outerSlot)]));
+}
+
+function makeTransferEvent(
+  token: string,
+  from: string,
+  to: string,
+  symbol: string | null = null,
+  decimals: number | null = null,
+): DecodedEvent {
+  return {
+    kind: "transfer",
+    token: token.toLowerCase(),
+    tokenSymbol: symbol,
+    tokenDecimals: decimals,
+    amountFormatted: "100",
+    amountRaw: "100",
+    from: from.toLowerCase(),
+    to: to.toLowerCase(),
+    direction: "send",
+  };
+}
+
+function makeApprovalEvent(
+  token: string,
+  owner: string,
+  spender: string,
+  amountRaw: string = "1000",
+  symbol: string | null = null,
+  decimals: number | null = null,
+): DecodedEvent {
+  return {
+    kind: "approval",
+    token: token.toLowerCase(),
+    tokenSymbol: symbol,
+    tokenDecimals: decimals,
+    amountFormatted: amountRaw,
+    amountRaw,
+    from: owner.toLowerCase(),
+    to: spender.toLowerCase(),
+    direction: "send",
+  };
+}
+
+// ── computeMappingSlot ────────────────────────────────────────────
+
+describe("computeMappingSlot", () => {
+  it("matches the standard Solidity mapping layout formula", () => {
+    const key = ALICE as Address;
+    const slot = 0n;
+    const expected = keccak256(encodeAbiParameters(abiParams, [key, slot]));
+    expect(__internal.computeMappingSlot(key, slot)).toBe(expected);
+  });
+
+  it("produces different slots for different base slots", () => {
+    const key = ALICE as Address;
+    const slot0 = __internal.computeMappingSlot(key, 0n);
+    const slot1 = __internal.computeMappingSlot(key, 1n);
+    expect(slot0).not.toBe(slot1);
+  });
+});
+
+// ── computeNestedMappingSlot ──────────────────────────────────────
+
+describe("computeNestedMappingSlot", () => {
+  it("matches the nested mapping formula for allowances", () => {
+    const owner = ALICE as Address;
+    const spender = SPENDER as Address;
+    const baseSlot = 1n;
+
+    const outerSlot = keccak256(encodeAbiParameters(abiParams, [owner, baseSlot]));
+    const expected = keccak256(
+      encodeAbiParameters(abiParams, [spender, BigInt(outerSlot)]),
+    );
+
+    expect(__internal.computeNestedMappingSlot(owner, spender, baseSlot)).toBe(expected);
+  });
+});
+
+// ── hexToUint256 ──────────────────────────────────────────────────
+
+describe("hexToUint256", () => {
+  it("converts zero", () => {
+    expect(__internal.hexToUint256(ZERO)).toBe(0n);
+  });
+
+  it("converts non-zero value", () => {
+    expect(__internal.hexToUint256(uint256Hex(12345n))).toBe(12345n);
+  });
+
+  it("handles empty string", () => {
+    expect(__internal.hexToUint256("")).toBe(0n);
+  });
+
+  it("handles bare 0x", () => {
+    expect(__internal.hexToUint256("0x")).toBe(0n);
+  });
+});
+
+// ── formatDelta ──────────────────────────────────────────────────
+
+describe("formatDelta", () => {
+  it("formats positive delta with symbol", () => {
+    const result = __internal.formatDelta(0n, 1000n * 10n ** 18n, 18, "DAI");
+    expect(result).toBe("+1,000 DAI");
+  });
+
+  it("formats negative delta with symbol", () => {
+    const result = __internal.formatDelta(500n * 10n ** 6n, 300n * 10n ** 6n, 6, "USDC");
+    expect(result).toContain("-200");
+    expect(result).toContain("USDC");
+  });
+
+  it("formats zero delta", () => {
+    expect(__internal.formatDelta(100n, 100n, 18, "DAI")).toBe("0 DAI");
+  });
+});
+
+// ── formatAllowanceAfter ─────────────────────────────────────────
+
+describe("formatAllowanceAfter", () => {
+  it("formats zero as '0'", () => {
+    expect(__internal.formatAllowanceAfter(0n, 18, "DAI")).toBe("0");
+  });
+
+  it("formats MAX_UINT256 as unlimited", () => {
+    const maxUint = (1n << 256n) - 1n;
+    expect(__internal.formatAllowanceAfter(maxUint, 18, "DAI")).toBe("Unlimited DAI");
+  });
+
+  it("formats normal amount with decimals", () => {
+    const result = __internal.formatAllowanceAfter(500n * 10n ** 6n, 6, "USDC");
+    expect(result).toContain("500");
+    expect(result).toContain("USDC");
+  });
+});
+
+// ── decodeERC20StateDiffs ─────────────────────────────────────────
+
+describe("decodeERC20StateDiffs", () => {
+  it("returns empty results when stateDiffs is undefined", () => {
+    const result = decodeERC20StateDiffs(undefined, []);
+    expect(result.balanceChanges).toEqual([]);
+    expect(result.allowances).toEqual([]);
+  });
+
+  it("returns empty results when stateDiffs is empty", () => {
+    const result = decodeERC20StateDiffs([], []);
+    expect(result.balanceChanges).toEqual([]);
+    expect(result.allowances).toEqual([]);
+  });
+
+  it("returns empty results when events have no matching diffs", () => {
+    const events = [makeTransferEvent(DAI, ALICE, BOB)];
+    // State diff on a different slot that doesn't match any layout
+    const diffs: StateDiffEntry[] = [
+      {
+        address: DAI,
+        key: "0x" + "ff".repeat(32),
+        before: ZERO,
+        after: uint256Hex(100n),
+      },
+    ];
+    const result = decodeERC20StateDiffs(diffs, events);
+    expect(result.balanceChanges).toEqual([]);
+  });
+
+  it("matches Transfer event to balance diffs using OZ layout (slot 0)", () => {
+    const senderSlot = mappingSlot(ALICE as Address, 0n);
+    const receiverSlot = mappingSlot(BOB as Address, 0n);
+
+    const diffs: StateDiffEntry[] = [
+      {
+        address: DAI,
+        key: senderSlot,
+        before: uint256Hex(1000n * 10n ** 18n),
+        after: uint256Hex(900n * 10n ** 18n),
+      },
+      {
+        address: DAI,
+        key: receiverSlot,
+        before: uint256Hex(0n),
+        after: uint256Hex(100n * 10n ** 18n),
+      },
+    ];
+
+    const events = [makeTransferEvent(DAI, ALICE, BOB, "DAI", 18)];
+    const result = decodeERC20StateDiffs(diffs, events);
+
+    expect(result.balanceChanges).toHaveLength(2);
+
+    const senderChange = result.balanceChanges.find((c) => c.account === ALICE.toLowerCase());
+    expect(senderChange).toBeDefined();
+    expect(senderChange!.deltaFormatted).toContain("-100");
+    expect(senderChange!.deltaFormatted).toContain("DAI");
+    expect(senderChange!.layoutName).toBe("oz");
+
+    const receiverChange = result.balanceChanges.find((c) => c.account === BOB.toLowerCase());
+    expect(receiverChange).toBeDefined();
+    expect(receiverChange!.deltaFormatted).toContain("+100");
+  });
+
+  it("matches Approval event to allowance diff using OZ layout (slot 1)", () => {
+    const allowanceSlotKey = nestedMappingSlot(
+      ALICE as Address,
+      SPENDER as Address,
+      1n, // OZ allowance slot
+    );
+
+    const diffs: StateDiffEntry[] = [
+      {
+        address: DAI,
+        key: allowanceSlotKey,
+        before: uint256Hex((1n << 256n) - 1n),
+        after: ZERO,
+      },
+    ];
+
+    const events = [makeApprovalEvent(DAI, ALICE, SPENDER, "0", "DAI", 18)];
+    const result = decodeERC20StateDiffs(diffs, events);
+
+    expect(result.allowances).toHaveLength(1);
+    expect(result.allowances[0]).toMatchObject({
+      token: DAI,
+      owner: ALICE.toLowerCase(),
+      spender: SPENDER.toLowerCase(),
+      afterFormatted: "0",
+      layoutName: "oz",
+    });
+  });
+
+  it("matches DAI layout (balance slot 2, allowance slot 3)", () => {
+    const balanceSlot = mappingSlot(ALICE as Address, 2n); // DAI balance slot
+    const allowanceSlotKey = nestedMappingSlot(
+      ALICE as Address,
+      SPENDER as Address,
+      3n, // DAI allowance slot
+    );
+
+    const diffs: StateDiffEntry[] = [
+      {
+        address: DAI,
+        key: balanceSlot,
+        before: uint256Hex(500n * 10n ** 18n),
+        after: uint256Hex(400n * 10n ** 18n),
+      },
+      {
+        address: DAI,
+        key: allowanceSlotKey,
+        before: uint256Hex(1000n * 10n ** 18n),
+        after: uint256Hex(900n * 10n ** 18n),
+      },
+    ];
+
+    const events = [
+      makeTransferEvent(DAI, ALICE, BOB, "DAI", 18),
+      makeApprovalEvent(DAI, ALICE, SPENDER, "900", "DAI", 18),
+    ];
+
+    const result = decodeERC20StateDiffs(diffs, events);
+
+    expect(result.balanceChanges.length).toBeGreaterThanOrEqual(1);
+    const balance = result.balanceChanges.find(
+      (c) => c.account === ALICE.toLowerCase() && c.layoutName === "dai",
+    );
+    expect(balance).toBeDefined();
+    expect(balance!.deltaFormatted).toContain("-100");
+
+    expect(result.allowances.length).toBeGreaterThanOrEqual(1);
+    const allowance = result.allowances.find((a) => a.layoutName === "dai");
+    expect(allowance).toBeDefined();
+  });
+
+  it("handles unlimited (MAX_UINT256) allowance after", () => {
+    const allowanceSlotKey = nestedMappingSlot(
+      ALICE as Address,
+      SPENDER as Address,
+      1n,
+    );
+
+    const maxUint = uint256Hex((1n << 256n) - 1n);
+    const diffs: StateDiffEntry[] = [
+      {
+        address: USDC,
+        key: allowanceSlotKey,
+        before: ZERO,
+        after: maxUint,
+      },
+    ];
+
+    const events = [
+      makeApprovalEvent(USDC, ALICE, SPENDER, ((1n << 256n) - 1n).toString(), "USDC", 6),
+    ];
+    const result = decodeERC20StateDiffs(diffs, events);
+
+    expect(result.allowances).toHaveLength(1);
+    expect(result.allowances[0]!.afterFormatted).toBe("Unlimited USDC");
+  });
+
+  it("deduplicates when multiple events match same account/layout", () => {
+    const senderSlot = mappingSlot(ALICE as Address, 0n);
+
+    const diffs: StateDiffEntry[] = [
+      {
+        address: DAI,
+        key: senderSlot,
+        before: uint256Hex(1000n * 10n ** 18n),
+        after: uint256Hex(800n * 10n ** 18n),
+      },
+    ];
+
+    // Two transfers from ALICE on same token
+    const events = [
+      makeTransferEvent(DAI, ALICE, BOB, "DAI", 18),
+      makeTransferEvent(DAI, ALICE, SPENDER, "DAI", 18),
+    ];
+
+    const result = decodeERC20StateDiffs(diffs, events);
+
+    // Should only match once per (token, account, layout)
+    const aliceChanges = result.balanceChanges.filter(
+      (c) => c.account === ALICE.toLowerCase() && c.layoutName === "oz",
+    );
+    expect(aliceChanges).toHaveLength(1);
+  });
+
+  it("handles case-insensitive address matching", () => {
+    const upperDAI = DAI.toUpperCase().replace("0X", "0x");
+    const senderSlot = mappingSlot(ALICE as Address, 0n);
+
+    const diffs: StateDiffEntry[] = [
+      {
+        address: upperDAI as Address,
+        key: senderSlot,
+        before: uint256Hex(100n),
+        after: uint256Hex(50n),
+      },
+    ];
+
+    const events = [makeTransferEvent(DAI, ALICE, BOB)];
+    const result = decodeERC20StateDiffs(diffs, events);
+
+    expect(result.balanceChanges).toHaveLength(1);
+  });
+
+  it("handles multiple tokens in the same transaction", () => {
+    const daiSlot = mappingSlot(ALICE as Address, 0n);
+    const usdcSlot = mappingSlot(ALICE as Address, 0n);
+
+    const diffs: StateDiffEntry[] = [
+      {
+        address: DAI,
+        key: daiSlot,
+        before: uint256Hex(1000n),
+        after: uint256Hex(900n),
+      },
+      {
+        address: USDC,
+        key: usdcSlot,
+        before: uint256Hex(500n),
+        after: uint256Hex(400n),
+      },
+    ];
+
+    const events = [
+      makeTransferEvent(DAI, ALICE, BOB, "DAI", 18),
+      makeTransferEvent(USDC, ALICE, BOB, "USDC", 6),
+    ];
+
+    const result = decodeERC20StateDiffs(diffs, events);
+
+    expect(result.balanceChanges).toHaveLength(2);
+    expect(result.balanceChanges.map((c) => c.token)).toContain(DAI);
+    expect(result.balanceChanges.map((c) => c.token)).toContain(USDC);
+  });
+
+  it("skips non-transfer/non-approval events", () => {
+    const senderSlot = mappingSlot(ALICE as Address, 0n);
+
+    const diffs: StateDiffEntry[] = [
+      {
+        address: DAI,
+        key: senderSlot,
+        before: uint256Hex(100n),
+        after: uint256Hex(50n),
+      },
+    ];
+
+    const events: DecodedEvent[] = [
+      {
+        kind: "wrap",
+        token: DAI,
+        tokenSymbol: "DAI",
+        tokenDecimals: 18,
+        amountFormatted: "50",
+        amountRaw: "50",
+        from: ALICE,
+        to: DAI,
+        direction: "send",
+      },
+    ];
+
+    const result = decodeERC20StateDiffs(diffs, events);
+    expect(result.balanceChanges).toHaveLength(0);
+    expect(result.allowances).toHaveLength(0);
+  });
+});

--- a/packages/core/src/lib/simulation/index.ts
+++ b/packages/core/src/lib/simulation/index.ts
@@ -34,3 +34,10 @@ export {
   type StateDiffSummary,
   type ContractStateDiff,
 } from "./summary";
+
+export {
+  decodeERC20StateDiffs,
+  type ProvenBalanceChange,
+  type ProvenAllowance,
+  type SlotDecoderResult,
+} from "./slot-decoder";

--- a/packages/core/src/lib/simulation/slot-decoder.ts
+++ b/packages/core/src/lib/simulation/slot-decoder.ts
@@ -1,0 +1,329 @@
+/**
+ * ERC-20 storage slot decoder.
+ *
+ * Correlates simulation state diffs with decoded events to identify
+ * proven balance and allowance changes at the storage level.
+ *
+ * Approach: for each Transfer/Approval event, compute candidate storage
+ * slot keys across known ERC-20 layouts and check if any match the
+ * observed state diffs. When a match is found, the before/after values
+ * from the state diff provide **proven** post-state balances/allowances
+ * — not just event heuristics.
+ *
+ * This is the foundation for issue #105: replacing event-only approval
+ * heuristics with proven post-state values.
+ */
+
+import {
+  keccak256,
+  encodeAbiParameters,
+  parseAbiParameters,
+  type Address,
+  type Hex,
+} from "viem";
+import type { StateDiffEntry } from "../types";
+import type { DecodedEvent } from "./event-decoder";
+
+// ── ERC-20 storage layout definitions ──────────────────────────────
+
+/**
+ * Known ERC-20 storage layouts.
+ *
+ * Different token implementations use different slot numbers for
+ * their `balanceOf` and `allowance` mappings. We try all known
+ * layouts and match against observed state diffs.
+ */
+interface ERC20StorageLayout {
+  name: string;
+  /** Slot number for `mapping(address => uint256) balanceOf` */
+  balanceSlot: bigint;
+  /** Slot number for `mapping(address => mapping(address => uint256)) allowance` */
+  allowanceSlot: bigint;
+}
+
+const ERC20_LAYOUTS: ERC20StorageLayout[] = [
+  // OpenZeppelin ERC20 (v3/v4/v5), most common layout
+  { name: "oz", balanceSlot: 0n, allowanceSlot: 1n },
+  // Vyper default (e.g. some Curve tokens)
+  { name: "vyper", balanceSlot: 1n, allowanceSlot: 2n },
+  // DAI and MakerDAO tokens
+  { name: "dai", balanceSlot: 2n, allowanceSlot: 3n },
+  // WETH (balance at slot 3, no standard allowance — but try 4)
+  { name: "weth", balanceSlot: 3n, allowanceSlot: 4n },
+  // USDC / bridged tokens behind proxies (slot 9/10)
+  { name: "usdc-proxy", balanceSlot: 9n, allowanceSlot: 10n },
+];
+
+// ── Slot computation ────────────────────────────────────────────────
+
+// Cache parsed ABI parameters to avoid re-parsing on every call
+const abiParams = parseAbiParameters("address, uint256");
+
+/**
+ * Compute the storage slot for a simple mapping(address => T) at a given base slot.
+ * Solidity: keccak256(abi.encode(key, slot))
+ */
+function computeMappingSlot(key: Address, baseSlot: bigint): Hex {
+  return keccak256(encodeAbiParameters(abiParams, [key, baseSlot]));
+}
+
+/**
+ * Compute the storage slot for a nested mapping(address => mapping(address => T)).
+ * Solidity: keccak256(abi.encode(innerKey, keccak256(abi.encode(outerKey, slot))))
+ */
+function computeNestedMappingSlot(
+  outerKey: Address,
+  innerKey: Address,
+  baseSlot: bigint,
+): Hex {
+  const outerSlot = computeMappingSlot(outerKey, baseSlot);
+  return keccak256(
+    encodeAbiParameters(abiParams, [innerKey, BigInt(outerSlot)]),
+  );
+}
+
+// ── Result types ────────────────────────────────────────────────────
+
+/** A proven ERC-20 balance change backed by a storage diff. */
+export type ProvenBalanceChange = {
+  /** Token contract address. */
+  token: string;
+  /** Resolved token symbol, or null. */
+  tokenSymbol: string | null;
+  /** Token decimals, or null if unknown. */
+  tokenDecimals: number | null;
+  /** Account whose balance changed. */
+  account: string;
+  /** Balance before execution (raw uint256 as hex). */
+  before: string;
+  /** Balance after execution (raw uint256 as hex). */
+  after: string;
+  /** Human-readable delta (e.g. "+1,500 DAI" or "-200 USDC"). */
+  deltaFormatted: string;
+  /** Which storage layout matched. */
+  layoutName: string;
+};
+
+/** A proven ERC-20 allowance backed by a storage diff. */
+export type ProvenAllowance = {
+  /** Token contract address. */
+  token: string;
+  /** Resolved token symbol, or null. */
+  tokenSymbol: string | null;
+  /** Token decimals, or null if unknown. */
+  tokenDecimals: number | null;
+  /** Allowance owner. */
+  owner: string;
+  /** Allowance spender. */
+  spender: string;
+  /** Allowance value before execution (raw uint256 as hex). */
+  before: string;
+  /** Allowance value after execution (raw uint256 as hex). */
+  after: string;
+  /** Human-readable post-state allowance (e.g. "0", "Unlimited USDC"). */
+  afterFormatted: string;
+  /** Which storage layout matched. */
+  layoutName: string;
+};
+
+/** Combined result of ERC-20 slot decoding. */
+export type SlotDecoderResult = {
+  /** Proven balance changes correlated with Transfer events. */
+  balanceChanges: ProvenBalanceChange[];
+  /** Proven allowances correlated with Approval events. */
+  allowances: ProvenAllowance[];
+};
+
+// ── Formatting helpers ──────────────────────────────────────────────
+
+const MAX_UINT256 = (1n << 256n) - 1n;
+
+function hexToUint256(hex: string): bigint {
+  if (!hex || hex === "0x" || hex === "0x" + "00".repeat(32)) return 0n;
+  return BigInt(hex);
+}
+
+function formatTokenAmount(
+  raw: bigint,
+  decimals: number | null,
+  symbol: string | null,
+): string {
+  if (decimals == null) {
+    const str = raw.toString();
+    return symbol ? `${str} ${symbol}` : str;
+  }
+
+  const divisor = 10n ** BigInt(decimals);
+  const whole = raw / divisor;
+  const remainder = (raw < 0n ? -raw : raw) % divisor;
+
+  const wholeStr = whole.toLocaleString("en-US");
+  const fractional = remainder
+    .toString()
+    .padStart(decimals, "0")
+    .slice(0, 4)
+    .replace(/0+$/, "");
+
+  let numStr: string;
+  if (fractional.length > 0) {
+    numStr = `${wholeStr}.${fractional}`;
+  } else if (whole === 0n && remainder > 0n) {
+    numStr = "<0.0001";
+  } else {
+    numStr = wholeStr;
+  }
+  return symbol ? `${numStr} ${symbol}` : numStr;
+}
+
+function formatDelta(
+  before: bigint,
+  after: bigint,
+  decimals: number | null,
+  symbol: string | null,
+): string {
+  const delta = after - before;
+  if (delta === 0n) return symbol ? `0 ${symbol}` : "0";
+  const sign = delta > 0n ? "+" : "-";
+  const absDelta = delta < 0n ? -delta : delta;
+  return `${sign}${formatTokenAmount(absDelta, decimals, symbol)}`;
+}
+
+function formatAllowanceAfter(
+  after: bigint,
+  decimals: number | null,
+  symbol: string | null,
+): string {
+  if (after === 0n) return "0";
+  if (after === MAX_UINT256) return `Unlimited${symbol ? ` ${symbol}` : ""}`;
+  return formatTokenAmount(after, decimals, symbol);
+}
+
+// ── Main decoder ────────────────────────────────────────────────────
+
+/**
+ * Decode ERC-20 balance and allowance changes from state diffs,
+ * correlating with Transfer/Approval events.
+ *
+ * For each event, candidate storage slot keys are computed across all
+ * known ERC-20 layouts. If a candidate key matches an observed state
+ * diff on the token contract, the before/after values are extracted
+ * as proven post-state data.
+ *
+ * @param stateDiffs  - Storage slot changes from the simulation.
+ * @param events      - Decoded simulation events (transfers, approvals).
+ * @returns Proven balance changes and allowances.
+ */
+export function decodeERC20StateDiffs(
+  stateDiffs: StateDiffEntry[] | undefined,
+  events: DecodedEvent[],
+): SlotDecoderResult {
+  if (!stateDiffs || stateDiffs.length === 0) {
+    return { balanceChanges: [], allowances: [] };
+  }
+
+  // Index state diffs by (address, key) for O(1) lookup
+  const diffIndex = new Map<string, StateDiffEntry>();
+  for (const diff of stateDiffs) {
+    const indexKey = `${diff.address.toLowerCase()}:${diff.key.toLowerCase()}`;
+    diffIndex.set(indexKey, diff);
+  }
+
+  const balanceChanges: ProvenBalanceChange[] = [];
+  const allowances: ProvenAllowance[] = [];
+
+  // Deduplicate: track which (token, account, layout) combos we've already matched
+  const seenBalances = new Set<string>();
+  const seenAllowances = new Set<string>();
+
+  // ── Process Transfer events → balance changes ──────────────────
+  for (const event of events) {
+    if (event.kind !== "transfer") continue;
+    const tokenLower = event.token.toLowerCase();
+
+    for (const layout of ERC20_LAYOUTS) {
+      // Check sender's balance slot
+      for (const account of [event.from, event.to]) {
+        const dedupeKey = `${tokenLower}:${account.toLowerCase()}:${layout.name}`;
+        if (seenBalances.has(dedupeKey)) continue;
+
+        const slotKey = computeMappingSlot(
+          account.toLowerCase() as Address,
+          layout.balanceSlot,
+        ).toLowerCase();
+        const diff = diffIndex.get(`${tokenLower}:${slotKey}`);
+        if (diff) {
+          seenBalances.add(dedupeKey);
+          const before = hexToUint256(diff.before);
+          const after = hexToUint256(diff.after);
+          balanceChanges.push({
+            token: tokenLower,
+            tokenSymbol: event.tokenSymbol,
+            tokenDecimals: event.tokenDecimals,
+            account: account.toLowerCase(),
+            before: diff.before,
+            after: diff.after,
+            deltaFormatted: formatDelta(
+              before,
+              after,
+              event.tokenDecimals,
+              event.tokenSymbol,
+            ),
+            layoutName: layout.name,
+          });
+        }
+      }
+    }
+  }
+
+  // ── Process Approval events → proven allowances ────────────────
+  for (const event of events) {
+    if (event.kind !== "approval") continue;
+    const tokenLower = event.token.toLowerCase();
+    const ownerLower = event.from.toLowerCase() as Address;
+    const spenderLower = event.to.toLowerCase() as Address;
+
+    for (const layout of ERC20_LAYOUTS) {
+      const dedupeKey = `${tokenLower}:${ownerLower}:${spenderLower}:${layout.name}`;
+      if (seenAllowances.has(dedupeKey)) continue;
+
+      const slotKey = computeNestedMappingSlot(
+        ownerLower,
+        spenderLower,
+        layout.allowanceSlot,
+      ).toLowerCase();
+      const diff = diffIndex.get(`${tokenLower}:${slotKey}`);
+      if (diff) {
+        seenAllowances.add(dedupeKey);
+        const afterValue = hexToUint256(diff.after);
+        allowances.push({
+          token: tokenLower,
+          tokenSymbol: event.tokenSymbol,
+          tokenDecimals: event.tokenDecimals,
+          owner: ownerLower,
+          spender: spenderLower,
+          before: diff.before,
+          after: diff.after,
+          afterFormatted: formatAllowanceAfter(
+            afterValue,
+            event.tokenDecimals,
+            event.tokenSymbol,
+          ),
+          layoutName: layout.name,
+        });
+      }
+    }
+  }
+
+  return { balanceChanges, allowances };
+}
+
+// ── Test-only exports ───────────────────────────────────────────────
+
+export const __internal = {
+  computeMappingSlot,
+  computeNestedMappingSlot,
+  ERC20_LAYOUTS,
+  hexToUint256,
+  formatDelta,
+  formatAllowanceAfter,
+};


### PR DESCRIPTION
## Summary
- Adds `slot-decoder.ts` that correlates simulation state diffs with decoded Transfer/Approval events across 5 known ERC-20 storage layouts (OZ, Vyper, DAI, WETH, USDC-proxy) to produce **proven** balance changes and allowance post-state values
- Integrates proven allowances into `computeRemainingApprovals()` — state-diff-backed data takes priority over event-only heuristics, with event-based fallback for pairs without proven data
- Wires `stateDiffs` through both generator (`page.tsx`) and desktop (`VerifyScreen.tsx`) UIs
- 24 unit tests covering slot computation, formatting, layout matching, deduplication, case-insensitive addresses, and multi-token scenarios

Toward #105.

## Test plan
- [x] All 589 existing tests pass (47 test files)
- [x] 24 new slot-decoder tests pass
- [x] Type-check passes for core, generator, and desktop packages
- [ ] CI green
- [ ] Bugbot clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes approval detection logic used to warn users about remaining token allowances; incorrect slot/layout matching or diff correlation could misreport approvals despite tests covering common layouts and edge cases.
> 
> **Overview**
> Adds an ERC-20 `slot-decoder` that correlates simulation `stateDiffs` with decoded `Transfer`/`Approval` events across several common storage layouts to derive *proven* post-state balances and allowances.
> 
> Updates `computeRemainingApprovals` to accept optional `stateDiffs` and prefer storage-backed allowance values (falling back to event-only heuristics when no diff match exists), and wires this new argument through both the generator and desktop UIs.
> 
> Exports the new decoder/types from `@safelens/core` and adds a comprehensive unit test suite covering slot computation, layout matching, formatting (including unlimited), deduplication, and address casing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 998b808e0e920b7e6a5ba86b20cdbab314b83e98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->