### PR TITLE
feat: surface proven balance changes and approval source badges

### DIFF
--- a/apps/desktop/src/screens/VerifyScreen.tsx
+++ b/apps/desktop/src/screens/VerifyScreen.tsx
@@ -11,6 +11,7 @@ import {
   decodeSimulationEvents,
   decodeNativeTransfers,
   computeRemainingApprovals,
+  computeProvenBalanceChanges,
   summarizeStateDiffs,
   normalizeCallSteps,
   verifyCalldata,
@@ -829,6 +830,10 @@ function ExecutionSafetyPanel({
     () => computeRemainingApprovals(decodedEvents, evidence.simulation?.stateDiffs),
     [decodedEvents, evidence.simulation?.stateDiffs],
   );
+  const provenBalances = useMemo(
+    () => computeProvenBalanceChanges(decodedEvents, evidence.simulation?.stateDiffs),
+    [decodedEvents, evidence.simulation?.stateDiffs],
+  );
   const stateDiffSummary = useMemo(
     () => summarizeStateDiffs(evidence.simulation?.stateDiffs, decodedEvents, evidence.safeAddress),
     [evidence.simulation?.stateDiffs, decodedEvents, evidence.safeAddress],
@@ -1011,6 +1016,25 @@ function ExecutionSafetyPanel({
                   : "No token movements detected."}
               </div>
             )}
+            {provenBalances.length > 0 && (
+              <div className="rounded-md border border-cyan-500/20 bg-cyan-500/5 px-3 py-2">
+                <div className="text-xs font-medium text-cyan-300">
+                  Proven balance changes
+                  <span className="ml-1.5 font-normal text-cyan-400/70">from storage</span>
+                </div>
+                <div className="mt-1.5 space-y-1.5">
+                  {provenBalances.map((bc, i) => (
+                    <div key={i} className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-cyan-300/90">
+                      <span className={bc.deltaFormatted.startsWith("-") ? "font-medium text-red-400" : "font-medium text-emerald-400"}>
+                        {bc.deltaFormatted}
+                      </span>
+                      <span className="text-cyan-400/60">on</span>
+                      <AddressDisplay address={bc.account} chainId={evidence.chainId} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
             {remainingApprovals.length > 0 && (
               <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
                 <div className="text-xs font-medium text-amber-200">
@@ -1024,6 +1048,11 @@ function ExecutionSafetyPanel({
                       </span>
                       <span className="text-amber-400/70">to</span>
                       <AddressDisplay address={approval.spender} chainId={evidence.chainId} />
+                      {approval.source === "state-diff" && (
+                        <span className="rounded bg-cyan-500/15 px-1 py-0.5 text-[10px] font-medium text-cyan-400">
+                          proven
+                        </span>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/apps/generator/app/page.tsx
+++ b/apps/generator/app/page.tsx
@@ -21,6 +21,7 @@ import {
   decodeSimulationEvents,
   decodeNativeTransfers,
   computeRemainingApprovals,
+  computeProvenBalanceChanges,
   summarizeStateDiffs,
   DEFAULT_SETTINGS_CONFIG,
   buildGenerationSources,
@@ -128,6 +129,7 @@ function EvidenceDisplay({
   const allEvents = [...nativeEvents, ...logEvents];
   const transfers = allEvents.filter((e) => e.kind !== "approval");
   const approvals = computeRemainingApprovals(allEvents, sim?.stateDiffs);
+  const provenBalances = computeProvenBalanceChanges(allEvents, sim?.stateDiffs);
   const stateDiffSummary = summarizeStateDiffs(sim?.stateDiffs, allEvents, evidence.safeAddress);
 
   return (
@@ -212,6 +214,25 @@ function EvidenceDisplay({
                 This is a witness-only package. No token movements were detected for this simulation.
               </div>
             )}
+            {provenBalances.length > 0 && (
+              <div className="rounded-md border border-cyan-500/20 bg-cyan-500/5 px-3 py-2">
+                <div className="text-xs font-medium text-cyan-300">
+                  Proven balance changes
+                  <span className="ml-1.5 font-normal text-cyan-400/70">from storage</span>
+                </div>
+                <div className="mt-1.5 space-y-1">
+                  {provenBalances.map((bc, i) => (
+                    <div key={i} className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-cyan-300/90">
+                      <span className={bc.deltaFormatted.startsWith("-") ? "font-medium text-red-400" : "font-medium text-emerald-400"}>
+                        {bc.deltaFormatted}
+                      </span>
+                      <span className="text-cyan-400/60">on</span>
+                      <AddressDisplay address={bc.account} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
             {approvals.length > 0 && (
               <div className="rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2">
                 <div className="text-xs font-medium text-amber-200">Remaining approvals</div>
@@ -223,6 +244,11 @@ function EvidenceDisplay({
                       </span>
                       <span className="text-amber-400/70">to</span>
                       <AddressDisplay address={a.spender} />
+                      {a.source === "state-diff" && (
+                        <span className="rounded bg-cyan-500/15 px-1 py-0.5 text-[10px] font-medium text-cyan-400">
+                          proven
+                        </span>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/packages/core/src/lib/simulation/index.ts
+++ b/packages/core/src/lib/simulation/index.ts
@@ -27,6 +27,7 @@ export {
 export {
   summarizeSimulationEvents,
   computeRemainingApprovals,
+  computeProvenBalanceChanges,
   summarizeStateDiffs,
   type SimulationEventsSummary,
   type SimulationTransferPreview,


### PR DESCRIPTION
## Summary
- Adds `computeProvenBalanceChanges()` in `summary.ts` — extracts deduplicated ERC-20 balance deltas from the slot decoder for direct UI consumption
- Renders a new **"Proven balance changes"** section (cyan-themed) in both generator and desktop UIs, showing per-account balance deltas backed by storage diffs (e.g. "+1,500 DAI", "-200 USDC")
- Adds a **"proven" badge** on state-diff-backed approvals to distinguish storage-proven allowances from event-only heuristics
- 4 new tests covering empty inputs, non-matching diffs, OZ layout correlation, and deduplication

This builds on PR #151 (slot decoder) to make proven data visible to users — the core UX improvement from issue #105.

Toward #105.

## Test plan
- [x] All 593 tests pass (47 test files)
- [x] 4 new tests for `computeProvenBalanceChanges`
- [x] Type-check passes for core, generator, and desktop
- [ ] CI green
- [ ] Bugbot clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new state-diff-derived balance delta computation and surfaces it in end-user UIs; risk is mainly incorrect/misleading display if slot correlation/deduping logic is wrong, but scope is limited to simulation summarization/presentation.
> 
> **Overview**
> Adds `computeProvenBalanceChanges()` to `@safelens/core` simulation summaries, exposing *storage-proven* ERC-20 balance deltas derived from simulation state diffs (deduped by `(token, account)`) and exporting it via `packages/core/src/lib/simulation/index.ts`.
> 
> Updates both Desktop `VerifyScreen` and Generator `page.tsx` to render a new **“Proven balance changes”** section when available, and adds a small **“proven”** badge next to remaining approvals whose source is `state-diff`.
> 
> Extends `summary.test.ts` with new coverage for `computeProvenBalanceChanges` (empty inputs, non-matching diffs, OZ layout match, and deduplication behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3aca802871eced35188713a087c295297261d58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->