### PR TITLE
refactor: single-pass slot decoder + memoize generator UI

### DIFF
--- a/apps/desktop/src/screens/VerifyScreen.tsx
+++ b/apps/desktop/src/screens/VerifyScreen.tsx
@@ -10,8 +10,7 @@ import {
   buildCoreExecutionSafetyFields,
   decodeSimulationEvents,
   decodeNativeTransfers,
-  computeRemainingApprovals,
-  computeProvenBalanceChanges,
+  computePostStateEffects,
   summarizeStateDiffs,
   normalizeCallSteps,
   verifyCalldata,
@@ -826,12 +825,8 @@ function ExecutionSafetyPanel({
     () => decodedEvents.filter((e) => e.kind !== "approval"),
     [decodedEvents],
   );
-  const remainingApprovals = useMemo(
-    () => computeRemainingApprovals(decodedEvents, evidence.simulation?.stateDiffs),
-    [decodedEvents, evidence.simulation?.stateDiffs],
-  );
-  const provenBalances = useMemo(
-    () => computeProvenBalanceChanges(decodedEvents, evidence.simulation?.stateDiffs),
+  const { remainingApprovals, provenBalanceChanges: provenBalances } = useMemo(
+    () => computePostStateEffects(decodedEvents, evidence.simulation?.stateDiffs),
     [decodedEvents, evidence.simulation?.stateDiffs],
   );
   const stateDiffSummary = useMemo(

--- a/packages/core/src/lib/simulation/index.ts
+++ b/packages/core/src/lib/simulation/index.ts
@@ -28,10 +28,12 @@ export {
   summarizeSimulationEvents,
   computeRemainingApprovals,
   computeProvenBalanceChanges,
+  computePostStateEffects,
   summarizeStateDiffs,
   type SimulationEventsSummary,
   type SimulationTransferPreview,
   type RemainingApproval,
+  type PostStateEffects,
   type StateDiffSummary,
   type ContractStateDiff,
 } from "./summary";


### PR DESCRIPTION
## Summary
- Eliminates redundant double `decodeERC20StateDiffs` call — both `computeRemainingApprovals` and `computeProvenBalanceChanges` were independently running the expensive keccak256 slot computation on the same data
- Adds `computePostStateEffects()` that calls the slot decoder once and returns both approvals and balance changes in a single pass
- Wraps all generator UI computations in `useMemo` (matching the desktop's existing pattern) — previously every re-render recomputed decoded events, approvals, balance changes, and state diff summaries
- Keeps `computeRemainingApprovals` and `computeProvenBalanceChanges` available as standalone functions for callers that only need one result

Toward #105.

## Test plan
- [x] All 596 tests pass (47 test files)
- [x] 3 new tests verifying `computePostStateEffects` matches individual functions
- [x] Type-check passes for core, generator, and desktop
- [ ] CI green
- [ ] Bugbot clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a performance/refactor change with added test coverage; behavioral risk is limited but could affect how approvals/balance diffs are surfaced if the shared decoding logic diverges from the prior two-call path.
> 
> **Overview**
> Introduces `computePostStateEffects` in `@safelens/core` to compute **remaining approvals** and **proven balance changes** from simulation state diffs in a single `decodeERC20StateDiffs` pass, refactoring existing helpers to share internal decoding/dedup logic and exporting the new `PostStateEffects` type.
> 
> Updates desktop `VerifyScreen` and the generator UI to use the combined helper (removing separate calls), and memoizes generator-side decoding/filtering/summarization (`useMemo`) to avoid recomputing simulation-derived data on every re-render.
> 
> Adds targeted unit tests asserting `computePostStateEffects` returns both results, matches the legacy per-function outputs, and handles missing state diffs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 061b9b409e4723d99f5998821252a898f1f28aac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->