### PR TITLE
refactor(core): extract shared formatTokenAmount + add ERC-1155 tests

### DIFF
--- a/packages/core/src/lib/simulation/__tests__/format.test.ts
+++ b/packages/core/src/lib/simulation/__tests__/format.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { formatTokenAmount } from "../format";
+
+describe("formatTokenAmount", () => {
+  describe("known decimals", () => {
+    it("formats zero", () => {
+      expect(formatTokenAmount(0n, 18, "WETH")).toBe("0 WETH");
+      expect(formatTokenAmount(0n, 6, null)).toBe("0");
+    });
+
+    it("formats whole amounts with thousands separators", () => {
+      expect(formatTokenAmount(5000n * 10n ** 18n, 18, "WETH")).toContain("5,000");
+      expect(formatTokenAmount(5000n * 10n ** 18n, 18, "WETH")).toContain("WETH");
+    });
+
+    it("formats fractional amounts up to 4 decimals", () => {
+      // 1.5 USDC = 1_500_000 raw (6 decimals)
+      expect(formatTokenAmount(1_500_000n, 6, "USDC")).toBe("1.5 USDC");
+    });
+
+    it("strips trailing fractional zeros", () => {
+      // 2.10 DAI → should show 2.1, not 2.10 or 2.1000
+      expect(formatTokenAmount(2_100_000_000_000_000_000n, 18, "DAI")).toBe("2.1 DAI");
+    });
+
+    it("shows <0.0001 for dust amounts", () => {
+      // 1 wei of WETH = too small for 4 decimal places
+      expect(formatTokenAmount(1n, 18, "WETH")).toBe("<0.0001 WETH");
+      // 100 wei (still under 0.0001 WETH = 10^14 wei)
+      expect(formatTokenAmount(100n, 18, null)).toBe("<0.0001");
+    });
+
+    it("formats large amounts correctly", () => {
+      // 1,234,567.89 DAI
+      const raw = 1_234_567_890_000_000_000_000_000n;
+      const result = formatTokenAmount(raw, 18, "DAI");
+      expect(result).toContain("1,234,567");
+      expect(result).toContain("DAI");
+    });
+
+    it("works without a symbol", () => {
+      expect(formatTokenAmount(1_000_000n, 6, null)).toBe("1");
+      expect(formatTokenAmount(1_500_000n, 6, null)).toBe("1.5");
+    });
+
+    it("truncates to 4 decimal places (no rounding)", () => {
+      // 1.123456789 with 9 decimals → show 1.1234
+      expect(formatTokenAmount(1_123_456_789n, 9, "TOK")).toBe("1.1234 TOK");
+    });
+  });
+
+  describe("null decimals (unknown token)", () => {
+    it("returns raw bigint as string", () => {
+      expect(formatTokenAmount(12345n, null, null)).toBe("12345");
+    });
+
+    it("appends symbol when available", () => {
+      expect(formatTokenAmount(42n, null, "???")).toBe("42 ???");
+    });
+
+    it("handles zero with null decimals", () => {
+      expect(formatTokenAmount(0n, null, "X")).toBe("0 X");
+    });
+  });
+});

--- a/packages/core/src/lib/simulation/event-decoder.ts
+++ b/packages/core/src/lib/simulation/event-decoder.ts
@@ -12,6 +12,7 @@
  */
 
 import type { SimulationLog, NativeTransfer } from "../types";
+import { formatTokenAmount } from "./format";
 
 // ── Event signatures (keccak256 hashes) ──────────────────────────────
 
@@ -152,29 +153,9 @@ function hexToDecimal(hex: string): string {
   return BigInt("0x" + clean).toString();
 }
 
-/** Format a raw token amount with decimals. */
+/** Format a raw token amount with decimals (delegates to shared formatter). */
 function formatAmount(raw: string, decimals: number, symbol: string | null): string {
-  const value = BigInt(raw);
-  if (value === 0n) return symbol ? `0 ${symbol}` : "0";
-
-  const divisor = BigInt(10) ** BigInt(decimals);
-  const whole = value / divisor;
-  const remainder = value % divisor;
-
-  // Use commas for thousands
-  const wholeStr = whole.toLocaleString("en-US");
-  const fractional = remainder.toString().padStart(decimals, "0").slice(0, 4).replace(/0+$/, "");
-
-  let numStr: string;
-  if (fractional.length > 0) {
-    numStr = `${wholeStr}.${fractional}`;
-  } else if (whole === 0n && remainder > 0n) {
-    // Non-zero amount too small for 4 decimal places (e.g. 1 wei of WETH)
-    numStr = "<0.0001";
-  } else {
-    numStr = wholeStr;
-  }
-  return symbol ? `${numStr} ${symbol}` : numStr;
+  return formatTokenAmount(BigInt(raw), decimals, symbol);
 }
 
 /** Look up token metadata. */

--- a/packages/core/src/lib/simulation/format.ts
+++ b/packages/core/src/lib/simulation/format.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared token amount formatting utilities.
+ *
+ * Used by both the event decoder (for display of decoded events) and
+ * the slot decoder (for proven balance/allowance deltas). Keeping
+ * this in one place prevents drift between the two formatters.
+ */
+
+/**
+ * Format a token amount for human-readable display.
+ *
+ * - Adds thousands separators (e.g. "1,234,567")
+ * - Shows up to 4 fractional digits, stripping trailing zeros
+ * - Shows "<0.0001" for dust amounts that round to zero at 4 decimals
+ * - Falls back to raw string when `decimals` is null (unknown token)
+ *
+ * @param raw      - Raw token amount as a bigint.
+ * @param decimals - Token decimals, or null for unknown tokens.
+ * @param symbol   - Token symbol for display, or null.
+ */
+export function formatTokenAmount(
+  raw: bigint,
+  decimals: number | null,
+  symbol: string | null,
+): string {
+  if (decimals == null) {
+    const str = raw.toString();
+    return symbol ? `${str} ${symbol}` : str;
+  }
+
+  if (raw === 0n) return symbol ? `0 ${symbol}` : "0";
+
+  const divisor = 10n ** BigInt(decimals);
+  const whole = raw / divisor;
+  const remainder = (raw < 0n ? -raw : raw) % divisor;
+
+  const wholeStr = whole.toLocaleString("en-US");
+  const fractional = remainder
+    .toString()
+    .padStart(decimals, "0")
+    .slice(0, 4)
+    .replace(/0+$/, "");
+
+  let numStr: string;
+  if (fractional.length > 0) {
+    numStr = `${wholeStr}.${fractional}`;
+  } else if (whole === 0n && remainder > 0n) {
+    numStr = "<0.0001";
+  } else {
+    numStr = wholeStr;
+  }
+  return symbol ? `${numStr} ${symbol}` : numStr;
+}

--- a/packages/core/src/lib/simulation/slot-decoder.ts
+++ b/packages/core/src/lib/simulation/slot-decoder.ts
@@ -23,6 +23,7 @@ import {
 } from "viem";
 import type { StateDiffEntry } from "../types";
 import type { DecodedEvent } from "./event-decoder";
+import { formatTokenAmount } from "./format";
 
 // ── ERC-20 storage layout definitions ──────────────────────────────
 
@@ -141,38 +142,6 @@ const MAX_UINT256 = (1n << 256n) - 1n;
 function hexToUint256(hex: string): bigint {
   if (!hex || hex === "0x" || hex === "0x" + "00".repeat(32)) return 0n;
   return BigInt(hex);
-}
-
-function formatTokenAmount(
-  raw: bigint,
-  decimals: number | null,
-  symbol: string | null,
-): string {
-  if (decimals == null) {
-    const str = raw.toString();
-    return symbol ? `${str} ${symbol}` : str;
-  }
-
-  const divisor = 10n ** BigInt(decimals);
-  const whole = raw / divisor;
-  const remainder = (raw < 0n ? -raw : raw) % divisor;
-
-  const wholeStr = whole.toLocaleString("en-US");
-  const fractional = remainder
-    .toString()
-    .padStart(decimals, "0")
-    .slice(0, 4)
-    .replace(/0+$/, "");
-
-  let numStr: string;
-  if (fractional.length > 0) {
-    numStr = `${wholeStr}.${fractional}`;
-  } else if (whole === 0n && remainder > 0n) {
-    numStr = "<0.0001";
-  } else {
-    numStr = wholeStr;
-  }
-  return symbol ? `${numStr} ${symbol}` : numStr;
 }
 
 function formatDelta(


### PR DESCRIPTION
## Summary
- Extracted the token amount formatter (duplicated between `event-decoder.ts` and `slot-decoder.ts`) into a shared `format.ts` module. Both files now import `formatTokenAmount` from the single source of truth.
- Added 11 unit tests for `formatTokenAmount` covering: zero, dust amounts (`<0.0001`), large numbers with thousands separators, fractional truncation, null-decimal fallback, and symbol handling.
- Added 3 tests for ERC-1155 `TransferSingle` and `TransferBatch` decoding (previously untested).

## Test plan
- [x] All 610 tests pass (14 new)
- [x] Type-check clean for desktop and generator
- [x] Pure refactor — no public API or runtime behavior changes
- [x] New test file `format.test.ts` covers all formatting edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a deduplication refactor plus new tests; runtime behavior should be effectively unchanged aside from minor formatting edge-case differences if the old implementations diverged.
> 
> **Overview**
> Refactors simulation formatting by extracting duplicated token amount display logic into a shared `formatTokenAmount` helper (`simulation/format.ts`) and updating both `event-decoder.ts` and `slot-decoder.ts` to use it.
> 
> Adds new unit coverage: a dedicated `format.test.ts` suite for formatting edge cases (zero, dust, separators, truncation, unknown decimals/symbol handling) and additional `event-decoder` tests covering ERC-1155 `TransferSingle`/`TransferBatch`, including graceful handling of malformed batch payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 759afb0e973560f729f3a790746490e4a7578e8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->