### PR TITLE
refactor(core): unify formatTokenAmount across interpret and simulation

### DIFF
--- a/packages/core/src/lib/interpret/__tests__/token-transfer.test.ts
+++ b/packages/core/src/lib/interpret/__tests__/token-transfer.test.ts
@@ -36,7 +36,7 @@ describe("interpretTokenTransfer", () => {
       const details = result!.details as TokenTransferDetails;
       expect(details.token.symbol).toBe("USDC");
       expect(details.token.decimals).toBe(6);
-      expect(details.amountFormatted).toBe("1.0000 USDC");
+      expect(details.amountFormatted).toBe("1 USDC");
     });
 
     it("produces a human-readable summary", () => {
@@ -211,7 +211,7 @@ describe("interpretTokenTransfer", () => {
         "0x", 1, "1500000000000000000",
       );
       const details = result!.details as TokenTransferDetails;
-      expect(details.amountFormatted).toBe("1.5000 ETH");
+      expect(details.amountFormatted).toBe("1.5 ETH");
     });
 
     it("sets recipient to txTo", () => {

--- a/packages/core/src/lib/interpret/__tests__/token-utils.test.ts
+++ b/packages/core/src/lib/interpret/__tests__/token-utils.test.ts
@@ -2,12 +2,32 @@ import { describe, expect, it } from "vitest";
 import { formatTokenAmount } from "../token-utils";
 
 describe("formatTokenAmount", () => {
-  it("formats standard 18-decimal values", () => {
-    expect(formatTokenAmount("1500000000000000000", 18)).toBe("1.5000");
+  it("formats standard 18-decimal values (strips trailing zeros)", () => {
+    expect(formatTokenAmount("1500000000000000000", 18)).toBe("1.5");
   });
 
   it("uses exact BigInt exponent math for high decimals", () => {
     const raw = (BigInt(10) ** BigInt(24)).toString();
-    expect(formatTokenAmount(raw, 24)).toBe("1.0000");
+    expect(formatTokenAmount(raw, 24)).toBe("1");
+  });
+
+  it("adds thousands separators for large values", () => {
+    // 5000 WETH
+    const raw = (5000n * 10n ** 18n).toString();
+    expect(formatTokenAmount(raw, 18)).toContain("5,000");
+  });
+
+  it("shows <0.0001 for dust amounts", () => {
+    // 1 wei of WETH
+    expect(formatTokenAmount("1", 18)).toBe("<0.0001");
+  });
+
+  it("formats zero as 0", () => {
+    expect(formatTokenAmount("0", 18)).toBe("0");
+  });
+
+  it("formats 6-decimal tokens correctly", () => {
+    // 1.5 USDC
+    expect(formatTokenAmount("1500000", 6)).toBe("1.5");
   });
 });

--- a/packages/core/src/lib/interpret/token-utils.ts
+++ b/packages/core/src/lib/interpret/token-utils.ts
@@ -6,6 +6,7 @@
  */
 
 import type { TokenInfo } from "./types";
+import { formatTokenAmount as formatTokenAmountShared } from "../simulation/format";
 
 // ── Well-known tokens (Ethereum Mainnet) ─────────────────────────────
 
@@ -39,14 +40,10 @@ export function resolveToken(address: string): TokenInfo {
 /**
  * Format a raw token amount with decimals.
  *
- * Uses pure BigInt arithmetic to avoid float64 precision loss
- * (safe for any decimal count, including > 18).
+ * Delegates to the shared `formatTokenAmount` in `simulation/format.ts`
+ * which provides thousands separators, trailing-zero stripping,
+ * and "<0.0001" for dust amounts.
  */
 export function formatTokenAmount(raw: string, decimals: number): string {
-  const value = BigInt(raw);
-  const divisor = BigInt(10) ** BigInt(decimals);
-  const whole = value / divisor;
-  const remainder = value % divisor;
-  const fractional = remainder.toString().padStart(decimals, "0").slice(0, 4);
-  return `${whole}.${fractional}`;
+  return formatTokenAmountShared(BigInt(raw), decimals, null);
 }


### PR DESCRIPTION
## Summary
- The interpret module (`token-utils.ts`) had its own `formatTokenAmount` implementation that always showed trailing zeros (e.g. `"1.5000"`) and lacked thousands separators. Replaced it with a thin wrapper around the shared formatter in `simulation/format.ts`.
- All token amounts across the app now use a consistent display style: `"1.5"` instead of `"1.5000"`, `"5,000"` instead of `"5000"`, and `"<0.0001"` for dust amounts.
- Added 4 new tests for the unified formatter in `token-utils.test.ts` (thousands separators, dust amounts, zero, 6-decimal tokens).

## Test plan
- [x] All 614 tests pass (4 new)
- [x] Type-check clean for desktop and generator
- [x] Updated assertions in `token-transfer.test.ts` to match improved formatting
- [x] No public API changes — only display formatting improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to display formatting and test expectations; primary impact is potential UI string diffs where amounts are rendered.
> 
> **Overview**
> Token amount formatting in `interpret/token-utils.ts` is refactored to delegate to the shared `simulation/format.ts` implementation instead of maintaining a separate BigInt formatter.
> 
> As a result, interpreter output now **strips trailing zeros**, **adds thousands separators**, and displays **dust** amounts as `"<0.0001"`; tests are updated accordingly (including `token-transfer` expectations) and new unit cases are added to cover the unified formatting behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42f2ca482db8c23047d9da46d5bb955ece748d10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->