### PR TITLE
refactor(core): extract shared well-known token registry

### DIFF
--- a/packages/core/src/lib/interpret/__tests__/token-utils.test.ts
+++ b/packages/core/src/lib/interpret/__tests__/token-utils.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { formatTokenAmount } from "../token-utils";
+import { formatTokenAmount, resolveToken } from "../token-utils";
+
+describe("resolveToken", () => {
+  it("resolves mainnet WETH without chainId (fallback)", () => {
+    const token = resolveToken("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+    expect(token.symbol).toBe("WETH");
+    expect(token.decimals).toBe(18);
+  });
+
+  it("resolves Polygon USDC with chainId", () => {
+    const token = resolveToken("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", 137);
+    expect(token.symbol).toBe("USDC");
+    expect(token.decimals).toBe(6);
+  });
+
+  it("returns address-only for unknown token", () => {
+    const addr = "0x0000000000000000000000000000000000000042";
+    const token = resolveToken(addr);
+    expect(token.address).toBe(addr);
+    expect(token.symbol).toBeUndefined();
+    expect(token.decimals).toBeUndefined();
+  });
+
+  it("resolves Arbitrum WETH with chainId", () => {
+    const token = resolveToken("0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", 42161);
+    expect(token.symbol).toBe("WETH");
+    expect(token.decimals).toBe(18);
+  });
+});
 
 describe("formatTokenAmount", () => {
   it("formats standard 18-decimal values (strips trailing zeros)", () => {

--- a/packages/core/src/lib/interpret/cowswap-twap.ts
+++ b/packages/core/src/lib/interpret/cowswap-twap.ts
@@ -81,7 +81,9 @@ export function decodeTwapOrderData(hexData: string): {
 export const interpretCowSwapTwap: Interpreter = (
   dataDecoded,
   _txTo,
-  txOperation
+  txOperation,
+  _txData,
+  chainId,
 ) => {
   if (txOperation !== 1) return null; // must be delegatecall (multiSend)
 
@@ -138,8 +140,8 @@ export const interpretCowSwapTwap: Interpreter = (
   // Decode the TWAP order data
   const order = decodeTwapOrderData(orderDataHex);
 
-  const sellToken = resolveToken(order.sellToken);
-  const buyToken = resolveToken(order.buyToken);
+  const sellToken = resolveToken(order.sellToken, chainId);
+  const buyToken = resolveToken(order.buyToken, chainId);
   const sellDecimals = sellToken.decimals ?? 18;
   const buyDecimals = buyToken.decimals ?? 18;
 
@@ -174,7 +176,7 @@ export const interpretCowSwapTwap: Interpreter = (
       (p) => p.name === "wad" || p.name === "amount" || p.name === "value"
     )?.value as string | undefined;
     if (spender && amount && approveTx.to) {
-      const approveToken = resolveToken(approveTx.to);
+      const approveToken = resolveToken(approveTx.to, chainId);
       approval = {
         token: approveToken,
         spender,

--- a/packages/core/src/lib/interpret/token-transfer.ts
+++ b/packages/core/src/lib/interpret/token-transfer.ts
@@ -92,7 +92,7 @@ export const interpretTokenTransfer: Interpreter = (
   if (!decoded?.method || !decoded.parameters) return null;
 
   const params = decoded.parameters;
-  const token = resolveToken(txTo);
+  const token = resolveToken(txTo, chainId);
   const decimals = token.decimals ?? 18;
   const tokenLabel = token.symbol ?? txTo.slice(0, 10) + "…";
 

--- a/packages/core/src/lib/interpret/token-utils.ts
+++ b/packages/core/src/lib/interpret/token-utils.ts
@@ -1,39 +1,20 @@
 /**
  * Shared token utilities used by multiple interpreters.
  *
- * Centralizes well-known token metadata, token resolution, and
- * amount formatting to avoid duplication across interpreter files.
+ * Centralizes token resolution and amount formatting to avoid
+ * duplication across interpreter files. Token metadata comes from
+ * the shared `tokens/well-known` registry.
  */
 
 import type { TokenInfo } from "./types";
 import { formatTokenAmount as formatTokenAmountShared } from "../simulation/format";
-
-// ── Well-known tokens (Ethereum Mainnet) ─────────────────────────────
-
-export const KNOWN_TOKENS: Record<string, { symbol: string; decimals: number }> = {
-  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": {
-    symbol: "WETH",
-    decimals: 18,
-  },
-  "0x6b175474e89094c44da98b954eedeac495271d0f": {
-    symbol: "DAI",
-    decimals: 18,
-  },
-  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": {
-    symbol: "USDC",
-    decimals: 6,
-  },
-  "0xdac17f958d2ee523a2206206994597c13d831ec7": {
-    symbol: "USDT",
-    decimals: 6,
-  },
-};
+import { resolveTokenMeta } from "../tokens/well-known";
 
 /** Resolve a token address to metadata (symbol, decimals). */
-export function resolveToken(address: string): TokenInfo {
-  const known = KNOWN_TOKENS[address.toLowerCase()];
-  return known
-    ? { address, symbol: known.symbol, decimals: known.decimals }
+export function resolveToken(address: string, chainId?: number): TokenInfo {
+  const meta = resolveTokenMeta(address, chainId);
+  return meta
+    ? { address, symbol: meta.symbol, decimals: meta.decimals }
     : { address };
 }
 

--- a/packages/core/src/lib/simulation/event-decoder.ts
+++ b/packages/core/src/lib/simulation/event-decoder.ts
@@ -13,6 +13,8 @@
 
 import type { SimulationLog, NativeTransfer } from "../types";
 import { formatTokenAmount } from "./format";
+import { resolveTokenMeta } from "../tokens/well-known";
+import type { TokenMeta } from "../tokens/well-known";
 
 // ── Event signatures (keccak256 hashes) ──────────────────────────────
 
@@ -39,70 +41,6 @@ const DEPOSIT_TOPIC =
 /** Withdrawal(address indexed src, uint256 wad): WETH unwrap */
 const WITHDRAWAL_TOPIC =
   "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65";
-
-// ── Well-known tokens ─────────────────────────────────────────────────
-
-interface TokenMeta {
-  symbol: string;
-  decimals: number;
-}
-
-/** Key: `chainId:lowercaseAddress`. If chainId is unknown, omit the prefix. */
-const WELL_KNOWN_TOKENS: Record<string, TokenMeta> = {
-  // Ethereum mainnet
-  "1:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": { symbol: "WETH", decimals: 18 },
-  "1:0x6b175474e89094c44da98b954eedeac495271d0f": { symbol: "DAI", decimals: 18 },
-  "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": { symbol: "USDC", decimals: 6 },
-  "1:0xdac17f958d2ee523a2206206994597c13d831ec7": { symbol: "USDT", decimals: 6 },
-  "1:0x2260fac5e5542a773aa44fbcfedf7c193bc2c599": { symbol: "WBTC", decimals: 8 },
-  "1:0x514910771af9ca656af840dff83e8264ecf986ca": { symbol: "LINK", decimals: 18 },
-  "1:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9": { symbol: "AAVE", decimals: 18 },
-  "1:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984": { symbol: "UNI", decimals: 18 },
-  "1:0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2": { symbol: "MKR", decimals: 18 },
-  "1:0xae7ab96520de3a18e5e111b5eaab095312d7fe84": { symbol: "stETH", decimals: 18 },
-  "1:0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0": { symbol: "wstETH", decimals: 18 },
-  "1:0xd533a949740bb3306d119cc777fa900ba034cd52": { symbol: "CRV", decimals: 18 },
-  "1:0xba100000625a3754423978a60c9317c58a424e3d": { symbol: "BAL", decimals: 18 },
-  "1:0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab": { symbol: "COW", decimals: 18 },
-  // Gnosis chain
-  "100:0xe91d153e0b41518a2ce8dd3d7944fa863463a97d": { symbol: "WXDAI", decimals: 18 },
-  "100:0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1": { symbol: "WETH", decimals: 18 },
-  "100:0xddafbb505ad214d7b80b1f830fccc89b60fb7a83": { symbol: "USDC", decimals: 6 },
-  "100:0x4ecaba5870353805a9f068101a40e0f32ed605c6": { symbol: "USDT", decimals: 6 },
-  "100:0x177127622c4a00f3d409b75571e12cb3c8973d3c": { symbol: "COW", decimals: 18 },
-  // Polygon
-  "137:0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270": { symbol: "WPOL", decimals: 18 },
-  "137:0x7ceb23fd6bc0add59e62ac25578270cff1b9f619": { symbol: "WETH", decimals: 18 },
-  "137:0x3c499c542cef5e3811e1192ce70d8cc03d5c3359": { symbol: "USDC", decimals: 6 },
-  "137:0xc2132d05d31c914a87c6611c10748aeb04b58e8f": { symbol: "USDT", decimals: 6 },
-  // Arbitrum One
-  "42161:0x82af49447d8a07e3bd95bd0d56f35241523fbab1": { symbol: "WETH", decimals: 18 },
-  "42161:0xaf88d065e77c8cc2239327c5edb3a432268e5831": { symbol: "USDC", decimals: 6 },
-  "42161:0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9": { symbol: "USDT", decimals: 6 },
-  // Optimism
-  "10:0x4200000000000000000000000000000000000006": { symbol: "WETH", decimals: 18 },
-  "10:0x0b2c639c533813f4aa9d7837caf62653d097ff85": { symbol: "USDC", decimals: 6 },
-  "10:0x94b008aa00579c1307b0ef2c499ad98a8ce58e58": { symbol: "USDT", decimals: 6 },
-  "10:0xda10009cbd5d07dd0cecc66161fc93d7c9000da1": { symbol: "DAI", decimals: 18 },
-  // Base
-  "8453:0x4200000000000000000000000000000000000006": { symbol: "WETH", decimals: 18 },
-  "8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913": { symbol: "USDC", decimals: 6 },
-  // Linea
-  "59144:0xe5d7c2a44ffddf6b295a15c148167daaaf5cf34f": { symbol: "WETH", decimals: 18 },
-  "59144:0x176211869ca2b568f2a7d4ee941e073a821ee1ff": { symbol: "USDC", decimals: 6 },
-  "59144:0xa219439258ca9da29e9cc4ce5596924745e12b93": { symbol: "USDT", decimals: 6 },
-  // Sepolia
-  "11155111:0xfff9976782d46cc05630d1f6ebab18b2324d6b14": { symbol: "WETH", decimals: 18 },
-};
-
-// Fallback: address-only lookup (no chain)
-const WELL_KNOWN_TOKENS_NO_CHAIN: Record<string, TokenMeta> = {
-  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": { symbol: "WETH", decimals: 18 },
-  "0x6b175474e89094c44da98b954eedeac495271d0f": { symbol: "DAI", decimals: 18 },
-  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": { symbol: "USDC", decimals: 6 },
-  "0xdac17f958d2ee523a2206206994597c13d831ec7": { symbol: "USDT", decimals: 6 },
-  "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599": { symbol: "WBTC", decimals: 8 },
-};
 
 // ── Decoded event types ───────────────────────────────────────────────
 
@@ -156,16 +94,6 @@ function hexToDecimal(hex: string): string {
 /** Format a raw token amount with decimals (delegates to shared formatter). */
 function formatAmount(raw: string, decimals: number, symbol: string | null): string {
   return formatTokenAmount(BigInt(raw), decimals, symbol);
-}
-
-/** Look up token metadata. */
-function resolveTokenMeta(address: string, chainId?: number): TokenMeta | null {
-  const lower = address.toLowerCase();
-  if (chainId !== undefined) {
-    const keyed = WELL_KNOWN_TOKENS[`${chainId}:${lower}`];
-    if (keyed) return keyed;
-  }
-  return WELL_KNOWN_TOKENS_NO_CHAIN[lower] ?? null;
 }
 
 /** Determine direction relative to the Safe address. */

--- a/packages/core/src/lib/tokens/__tests__/well-known.test.ts
+++ b/packages/core/src/lib/tokens/__tests__/well-known.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { resolveTokenMeta } from "../well-known";
+
+describe("resolveTokenMeta", () => {
+  it("returns null for unknown token", () => {
+    expect(resolveTokenMeta("0x0000000000000000000000000000000000000001")).toBeNull();
+  });
+
+  it("resolves mainnet WETH by chain ID", () => {
+    const meta = resolveTokenMeta("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", 1);
+    expect(meta).toEqual({ symbol: "WETH", decimals: 18 });
+  });
+
+  it("resolves mainnet USDC by chain ID", () => {
+    const meta = resolveTokenMeta("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", 1);
+    expect(meta).toEqual({ symbol: "USDC", decimals: 6 });
+  });
+
+  it("resolves Polygon WPOL by chain ID", () => {
+    const meta = resolveTokenMeta("0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270", 137);
+    expect(meta).toEqual({ symbol: "WPOL", decimals: 18 });
+  });
+
+  it("resolves Arbitrum WETH by chain ID", () => {
+    const meta = resolveTokenMeta("0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", 42161);
+    expect(meta).toEqual({ symbol: "WETH", decimals: 18 });
+  });
+
+  it("resolves Optimism DAI by chain ID", () => {
+    const meta = resolveTokenMeta("0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1", 10);
+    expect(meta).toEqual({ symbol: "DAI", decimals: 18 });
+  });
+
+  it("resolves Base USDC by chain ID", () => {
+    const meta = resolveTokenMeta("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", 8453);
+    expect(meta).toEqual({ symbol: "USDC", decimals: 6 });
+  });
+
+  it("resolves Gnosis COW by chain ID", () => {
+    const meta = resolveTokenMeta("0x177127622c4A00F3d409B75571e12cB3c8973d3c", 100);
+    expect(meta).toEqual({ symbol: "COW", decimals: 18 });
+  });
+
+  it("falls back to address-only lookup when chainId is undefined", () => {
+    const meta = resolveTokenMeta("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+    expect(meta).toEqual({ symbol: "WETH", decimals: 18 });
+  });
+
+  it("falls back to address-only lookup for unknown chain", () => {
+    const meta = resolveTokenMeta("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", 999999);
+    expect(meta).toEqual({ symbol: "USDC", decimals: 6 });
+  });
+
+  it("returns null for Polygon-only token without chain ID", () => {
+    // WPOL only exists with chain prefix, no fallback entry
+    expect(resolveTokenMeta("0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270")).toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    const upper = resolveTokenMeta("0xC02AAA39B223FE8D0A0E5C4F27EAD9083C756CC2", 1);
+    const lower = resolveTokenMeta("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 1);
+    expect(upper).toEqual(lower);
+    expect(upper).not.toBeNull();
+  });
+});

--- a/packages/core/src/lib/tokens/well-known.ts
+++ b/packages/core/src/lib/tokens/well-known.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared well-known token metadata registry.
+ *
+ * Single source of truth for token symbol/decimals resolution,
+ * consumed by both the simulation event decoder and the transaction
+ * interpretation module.
+ *
+ * Key format: `chainId:lowercaseAddress` for chain-specific lookups.
+ * Fallback entries (no chain prefix) used when chainId is unavailable.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface TokenMeta {
+  symbol: string;
+  decimals: number;
+}
+
+// ── Chain-scoped registry ────────────────────────────────────────────
+
+/** Key: `chainId:lowercaseAddress` */
+const CHAIN_TOKENS: Record<string, TokenMeta> = {
+  // Ethereum mainnet
+  "1:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": { symbol: "WETH", decimals: 18 },
+  "1:0x6b175474e89094c44da98b954eedeac495271d0f": { symbol: "DAI", decimals: 18 },
+  "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": { symbol: "USDC", decimals: 6 },
+  "1:0xdac17f958d2ee523a2206206994597c13d831ec7": { symbol: "USDT", decimals: 6 },
+  "1:0x2260fac5e5542a773aa44fbcfedf7c193bc2c599": { symbol: "WBTC", decimals: 8 },
+  "1:0x514910771af9ca656af840dff83e8264ecf986ca": { symbol: "LINK", decimals: 18 },
+  "1:0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9": { symbol: "AAVE", decimals: 18 },
+  "1:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984": { symbol: "UNI", decimals: 18 },
+  "1:0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2": { symbol: "MKR", decimals: 18 },
+  "1:0xae7ab96520de3a18e5e111b5eaab095312d7fe84": { symbol: "stETH", decimals: 18 },
+  "1:0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0": { symbol: "wstETH", decimals: 18 },
+  "1:0xd533a949740bb3306d119cc777fa900ba034cd52": { symbol: "CRV", decimals: 18 },
+  "1:0xba100000625a3754423978a60c9317c58a424e3d": { symbol: "BAL", decimals: 18 },
+  "1:0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab": { symbol: "COW", decimals: 18 },
+  // Gnosis chain
+  "100:0xe91d153e0b41518a2ce8dd3d7944fa863463a97d": { symbol: "WXDAI", decimals: 18 },
+  "100:0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1": { symbol: "WETH", decimals: 18 },
+  "100:0xddafbb505ad214d7b80b1f830fccc89b60fb7a83": { symbol: "USDC", decimals: 6 },
+  "100:0x4ecaba5870353805a9f068101a40e0f32ed605c6": { symbol: "USDT", decimals: 6 },
+  "100:0x177127622c4a00f3d409b75571e12cb3c8973d3c": { symbol: "COW", decimals: 18 },
+  // Polygon
+  "137:0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270": { symbol: "WPOL", decimals: 18 },
+  "137:0x7ceb23fd6bc0add59e62ac25578270cff1b9f619": { symbol: "WETH", decimals: 18 },
+  "137:0x3c499c542cef5e3811e1192ce70d8cc03d5c3359": { symbol: "USDC", decimals: 6 },
+  "137:0xc2132d05d31c914a87c6611c10748aeb04b58e8f": { symbol: "USDT", decimals: 6 },
+  // Arbitrum One
+  "42161:0x82af49447d8a07e3bd95bd0d56f35241523fbab1": { symbol: "WETH", decimals: 18 },
+  "42161:0xaf88d065e77c8cc2239327c5edb3a432268e5831": { symbol: "USDC", decimals: 6 },
+  "42161:0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9": { symbol: "USDT", decimals: 6 },
+  // Optimism
+  "10:0x4200000000000000000000000000000000000006": { symbol: "WETH", decimals: 18 },
+  "10:0x0b2c639c533813f4aa9d7837caf62653d097ff85": { symbol: "USDC", decimals: 6 },
+  "10:0x94b008aa00579c1307b0ef2c499ad98a8ce58e58": { symbol: "USDT", decimals: 6 },
+  "10:0xda10009cbd5d07dd0cecc66161fc93d7c9000da1": { symbol: "DAI", decimals: 18 },
+  // Base
+  "8453:0x4200000000000000000000000000000000000006": { symbol: "WETH", decimals: 18 },
+  "8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913": { symbol: "USDC", decimals: 6 },
+  // Linea
+  "59144:0xe5d7c2a44ffddf6b295a15c148167daaaf5cf34f": { symbol: "WETH", decimals: 18 },
+  "59144:0x176211869ca2b568f2a7d4ee941e073a821ee1ff": { symbol: "USDC", decimals: 6 },
+  "59144:0xa219439258ca9da29e9cc4ce5596924745e12b93": { symbol: "USDT", decimals: 6 },
+  // Sepolia
+  "11155111:0xfff9976782d46cc05630d1f6ebab18b2324d6b14": { symbol: "WETH", decimals: 18 },
+};
+
+/** Fallback: address-only lookup (no chain). Used when chainId is unavailable. */
+const FALLBACK_TOKENS: Record<string, TokenMeta> = {
+  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": { symbol: "WETH", decimals: 18 },
+  "0x6b175474e89094c44da98b954eedeac495271d0f": { symbol: "DAI", decimals: 18 },
+  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": { symbol: "USDC", decimals: 6 },
+  "0xdac17f958d2ee523a2206206994597c13d831ec7": { symbol: "USDT", decimals: 6 },
+  "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599": { symbol: "WBTC", decimals: 8 },
+};
+
+// ── Lookup ────────────────────────────────────────────────────────────
+
+/**
+ * Resolve token metadata by address and optional chain ID.
+ *
+ * Tries chain-scoped lookup first, falls back to address-only.
+ * Returns null for unknown tokens.
+ */
+export function resolveTokenMeta(address: string, chainId?: number): TokenMeta | null {
+  const lower = address.toLowerCase();
+  if (chainId !== undefined) {
+    const keyed = CHAIN_TOKENS[`${chainId}:${lower}`];
+    if (keyed) return keyed;
+  }
+  return FALLBACK_TOKENS[lower] ?? null;
+}


### PR DESCRIPTION
## Summary

- Extracts a single `tokens/well-known.ts` registry from duplicated token metadata in `event-decoder.ts` (40+ multi-chain tokens) and `interpret/token-utils.ts` (4 mainnet-only tokens)
- The interpret module's `resolveToken()` now accepts an optional `chainId`, giving transaction interpretations (transfer, approve, TWAP) access to the full multi-chain token set — previously they showed raw addresses for any non-mainnet token
- Net: removes 55 lines of duplicated registry data from event-decoder and 18 lines from token-utils

## Changes

| File | Change |
|---|---|
| `tokens/well-known.ts` | **New** — shared `resolveTokenMeta(address, chainId?)` with chain-scoped + fallback lookup |
| `simulation/event-decoder.ts` | Removed inline 55-line registry + local `resolveTokenMeta`, imports shared module |
| `interpret/token-utils.ts` | Removed `KNOWN_TOKENS` map, delegates `resolveToken` to shared registry |
| `interpret/token-transfer.ts` | Passes `chainId` to `resolveToken` |
| `interpret/cowswap-twap.ts` | Destructures `chainId` from params, passes to 3 `resolveToken` calls |
| `tokens/__tests__/well-known.test.ts` | **New** — 12 tests (chain-scoped, fallback, case-insensitive, unknown) |
| `interpret/__tests__/token-utils.test.ts` | 4 new tests for chain-aware `resolveToken` |

## Test plan

- [x] 16 new tests pass (12 registry + 4 resolveToken)
- [x] All 99 relevant tests pass (event-decoder, token-utils, token-transfer, cowswap)
- [x] Type-check clean (desktop + generator)
- [x] No behavioral changes for simulation event decoding (same registry, same lookup logic)
- [x] Interpret module now resolves tokens on all supported chains (Polygon, Arbitrum, Optimism, Base, Linea, Gnosis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because token symbol/decimals resolution is centralized and now chain-aware, which affects how multiple interpreters and the simulation decoder label/format assets across chains.
> 
> **Overview**
> **Unifies token metadata lookup** by introducing `tokens/well-known.ts` as the single registry for symbol/decimals resolution (chain-scoped with address-only fallback).
> 
> **Refactors consumers** to use the shared `resolveTokenMeta` and removes duplicated in-file token maps, while making `interpret`’s `resolveToken(address, chainId?)` chain-aware so `token-transfer` and `cowswap-twap` resolve non-mainnet tokens instead of showing raw addresses.
> 
> **Adds coverage** with new tests for `resolveTokenMeta` and chain-aware `resolveToken` fallback/unknown-token behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b8da444275736db673957e305ed83aaf098cfd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->