### PR TITLE
fix(core): resolve token symbols for silent contracts in state diff summary

### DIFF
--- a/apps/desktop/src/screens/VerifyScreen.tsx
+++ b/apps/desktop/src/screens/VerifyScreen.tsx
@@ -830,8 +830,8 @@ function ExecutionSafetyPanel({
     [decodedEvents, evidence.simulation?.stateDiffs],
   );
   const stateDiffSummary = useMemo(
-    () => summarizeStateDiffs(evidence.simulation?.stateDiffs, decodedEvents, evidence.safeAddress),
-    [evidence.simulation?.stateDiffs, decodedEvents, evidence.safeAddress],
+    () => summarizeStateDiffs(evidence.simulation?.stateDiffs, decodedEvents, evidence.safeAddress, evidence.chainId),
+    [evidence.simulation?.stateDiffs, decodedEvents, evidence.safeAddress, evidence.chainId],
   );
 
   const simulationAvailable = Boolean(evidence.simulation);

--- a/apps/generator/app/page.tsx
+++ b/apps/generator/app/page.tsx
@@ -134,8 +134,8 @@ function EvidenceDisplay({
     [allEvents, sim?.stateDiffs],
   );
   const stateDiffSummary = useMemo(
-    () => summarizeStateDiffs(sim?.stateDiffs, allEvents, evidence.safeAddress),
-    [sim?.stateDiffs, allEvents, evidence.safeAddress],
+    () => summarizeStateDiffs(sim?.stateDiffs, allEvents, evidence.safeAddress, evidence.chainId),
+    [sim?.stateDiffs, allEvents, evidence.safeAddress, evidence.chainId],
   );
 
   return (

--- a/packages/core/src/lib/simulation/event-decoder.ts
+++ b/packages/core/src/lib/simulation/event-decoder.ts
@@ -14,7 +14,6 @@
 import type { SimulationLog, NativeTransfer } from "../types";
 import { formatTokenAmount } from "./format";
 import { resolveTokenMeta } from "../tokens/well-known";
-import type { TokenMeta } from "../tokens/well-known";
 
 // ── Event signatures (keccak256 hashes) ──────────────────────────────
 

--- a/packages/core/src/lib/simulation/summary.ts
+++ b/packages/core/src/lib/simulation/summary.ts
@@ -1,6 +1,7 @@
 import type { SimulationLog, NativeTransfer, StateDiffEntry } from "../types";
 import { decodeSimulationEvents, decodeNativeTransfers, type DecodedEvent } from "./event-decoder";
 import { decodeERC20StateDiffs, type ProvenAllowance, type ProvenBalanceChange, type SlotDecoderResult } from "./slot-decoder";
+import { resolveTokenMeta } from "../tokens/well-known";
 
 export type SimulationTransferPreview = {
   direction: "send" | "receive" | "internal";
@@ -282,6 +283,7 @@ export function summarizeStateDiffs(
   stateDiffs: StateDiffEntry[] | undefined,
   events: DecodedEvent[],
   safeAddress?: string,
+  chainId?: number,
 ): StateDiffSummary {
   if (!stateDiffs || stateDiffs.length === 0) {
     return {
@@ -320,7 +322,9 @@ export function summarizeStateDiffs(
   for (const [address, slotsChanged] of byContract) {
     contracts.push({
       address,
-      tokenSymbol: tokenSymbols.get(address) ?? null,
+      tokenSymbol: tokenSymbols.get(address)
+        ?? resolveTokenMeta(address, chainId)?.symbol
+        ?? null,
       slotsChanged,
       hasEvents: eventContracts.has(address),
     });


### PR DESCRIPTION
## Summary

- `summarizeStateDiffs` now accepts optional `chainId` and falls back to the shared `resolveTokenMeta()` registry when no event-derived token symbol is available
- Silent contracts (storage changes without events) that are well-known tokens now show proper symbols (e.g. "USDC") instead of raw addresses
- Removes unused `TokenMeta` type import from `event-decoder.ts`

## Why this matters

Silent contracts are the most suspicious entries in the state diff summary — they signal hidden effects like allowance consumption via `transferFrom` without an `Approval` event. Showing the token symbol makes them immediately identifiable to users reviewing the transaction.

**Before:** Silent USDC contract shows as `0xa0b8...` with no token badge
**After:** Silent USDC contract shows with a "USDC" badge, making it clear what token had hidden storage changes

## Changes

| File | Change |
|---|---|
| `simulation/summary.ts` | Add `chainId?` param, fall back to `resolveTokenMeta` for symbol resolution |
| `simulation/event-decoder.ts` | Remove unused `TokenMeta` type import |
| `desktop/VerifyScreen.tsx` | Pass `evidence.chainId` to `summarizeStateDiffs` |
| `generator/page.tsx` | Pass `evidence.chainId` to `summarizeStateDiffs` |
| `simulation/__tests__/summary.test.ts` | 4 new tests |

## Test plan

- [x] 4 new tests: silent contract resolution, multi-chain (Polygon USDC), event-symbol priority, unknown contract null fallback
- [x] All 621 tests pass (4 new + 617 existing)
- [x] Type-check clean (desktop + generator)
- [x] Backward compatible — `chainId` is optional, existing callers without it still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to summary formatting logic plus UI call-site wiring; low risk with new unit tests validating symbol resolution behavior.
> 
> **Overview**
> Fixes state-diff summaries so **"silent" contracts** (storage changes without decoded events) can still display a token badge by extending `summarizeStateDiffs` with an optional `chainId` and falling back to the well-known token registry when no event-derived symbol exists.
> 
> Updates desktop `VerifyScreen` and the generator UI to pass `chainId` into `summarizeStateDiffs`, removes an unused `TokenMeta` import, and adds targeted tests covering registry resolution (including multi-chain USDC), event-symbol precedence, and unknown-token behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaf9e95e280bad6d174ad39f4a65ea1ae2119df6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->