### PR TITLE
fix(core): enforce integer validation on Zod schemas + wss:// URL redaction

### DIFF
--- a/packages/core/src/lib/package/creator.ts
+++ b/packages/core/src/lib/package/creator.ts
@@ -181,7 +181,7 @@ export async function enrichWithSimulation(
           ? error
           : "(unknown error)";
     witnessGenerationError = rawMessage.replace(
-      /https?:\/\/[^\s"',)}\]]+/gi,
+      /(?:https?|wss?):\/\/[^\s"',)}\]]+/gi,
       (url) => {
         try {
           const parsed = new URL(url);

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -47,11 +47,11 @@ export const safeTransactionSchema = z.object({
   baseGas: z.coerce.string().pipe(evmQuantitySchema),
   gasPrice: z.coerce.string().pipe(evmQuantitySchema),
   refundReceiver: addressSchema,
-  nonce: z.number(),
+  nonce: z.number().int(),
   executionDate: z.string().nullable(),
   submissionDate: z.string(),
   modified: z.string(),
-  blockNumber: z.number().nullable(),
+  blockNumber: z.number().int().nullable(),
   transactionHash: hashSchema.nullable(),
   safeTxHash: hashSchema,
   executor: addressSchema.nullable(),
@@ -60,11 +60,11 @@ export const safeTransactionSchema = z.object({
   ethGasPrice: z.string().nullable(),
   maxFeePerGas: z.string().nullable(),
   maxPriorityFeePerGas: z.string().nullable(),
-  gasUsed: z.number().nullable(),
+  gasUsed: z.number().int().nullable(),
   fee: z.string().nullable(),
   origin: z.string().nullable(),
   dataDecoded: z.any().nullable(),
-  confirmationsRequired: z.number(),
+  confirmationsRequired: z.number().int(),
   confirmations: z.array(
     z.object({
       owner: addressSchema,
@@ -114,7 +114,7 @@ export const accountProofSchema = z.object({
   address: addressSchema,
   balance: evmQuantitySchema,
   codeHash: hashSchema,
-  nonce: z.number(),
+  nonce: z.number().int(),
   storageHash: hashSchema,
   accountProof: z.array(hexDataSchema),
   storageProof: z.array(storageProofEntrySchema),
@@ -124,13 +124,13 @@ export type AccountProof = z.infer<typeof accountProofSchema>;
 
 // On-chain policy proof section (Phase 2 will populate these)
 export const onchainPolicyProofSchema = z.object({
-  blockNumber: z.number(),
+  blockNumber: z.number().int(),
   stateRoot: hashSchema,
   accountProof: accountProofSchema,
   decodedPolicy: z.object({
     owners: z.array(addressSchema),
-    threshold: z.number(),
-    nonce: z.number(),
+    threshold: z.number().int(),
+    nonce: z.number().int(),
     modules: z.array(addressSchema),
     guard: addressSchema,
     fallbackHandler: addressSchema,
@@ -176,7 +176,7 @@ const consensusProofBaseSchema = z.object({
   /** The EVM execution state root extracted from a finalized or verified execution payload. */
   stateRoot: hashSchema,
   /** Block number for the execution payload associated with `stateRoot`. */
-  blockNumber: z.number(),
+  blockNumber: z.number().int(),
 });
 
 // Beacon consensus proof section (Phase 4: Helios light client verification).
@@ -225,7 +225,7 @@ export const simulationSchema = z.object({
   logs: z.array(simulationLogSchema),
   nativeTransfers: z.array(nativeTransferSchema).optional(),
   stateDiffs: z.array(stateDiffEntrySchema).optional(),
-  blockNumber: z.number(),
+  blockNumber: z.number().int(),
   /** RFC3339 timestamp for the block used during simulation, when available. */
   blockTimestamp: z.string().datetime({ offset: true }).optional(),
   /** Whether debug_traceCall was available on the RPC. When false, logs and
@@ -257,9 +257,9 @@ export type SimulationReplayBlock = z.infer<typeof simulationReplayBlockSchema>;
 // This does not include a full execution proof; it anchors simulation context
 // to a proven state root and binds the simulation payload with a digest.
 export const simulationWitnessSchema = z.object({
-  chainId: z.number(),
+  chainId: z.number().int(),
   safeAddress: addressSchema,
-  blockNumber: z.number(),
+  blockNumber: z.number().int(),
   stateRoot: hashSchema,
   safeAccountProof: accountProofSchema,
   overriddenSlots: z.array(
@@ -396,13 +396,13 @@ export const evidencePackageSchema = z.object({
   version: z.union([z.literal("1.0"), z.literal("1.1"), z.literal("1.2")]),
   safeAddress: addressSchema,
   safeTxHash: hashSchema,
-  chainId: z.number(),
+  chainId: z.number().int(),
   transaction: z.object({
     to: addressSchema,
     value: evmQuantitySchema,
     data: hexDataSchema.nullable(),
     operation: z.union([z.literal(0), z.literal(1)]),
-    nonce: z.number(),
+    nonce: z.number().int(),
     safeTxGas: evmQuantitySchema,
     baseGas: evmQuantitySchema,
     gasPrice: evmQuantitySchema,
@@ -416,7 +416,7 @@ export const evidencePackageSchema = z.object({
       submissionDate: z.string(),
     })
   ),
-  confirmationsRequired: z.number(),
+  confirmationsRequired: z.number().int(),
   ethereumTxHash: hashSchema.nullable().optional(),
   dataDecoded: z.any().nullable().optional(),
   onchainPolicyProof: onchainPolicyProofSchema.optional(),
@@ -453,7 +453,7 @@ export type SafeUrlParseResult =
 
 // Paginated response from Safe Transaction Service
 export const safeTransactionListSchema = z.object({
-  count: z.number(),
+  count: z.number().int(),
   next: z.string().nullable(),
   previous: z.string().nullable(),
   results: z.array(safeTransactionSchema),


### PR DESCRIPTION
## Summary

Two security hardening fixes:

**1. Schema integer enforcement (types.ts)**

16 Zod schema fields used bare `z.number()` which silently accepts fractional values like `nonce: 3.14` or `chainId: 1.5`. These fields must be integers — the Rust desktop verifier expects `u64` and would reject or truncate fractional values. AUDIT.md already documented this fix as deployed, but the actual schemas were missing `.int()`.

Fields fixed across 6 schemas:

| Schema | Fields |
|---|---|
| `safeTransactionSchema` | `nonce`, `blockNumber`, `gasUsed`, `confirmationsRequired` |
| `accountProofSchema` | `nonce` |
| `onchainPolicyProofSchema` | `blockNumber`, `threshold`, `nonce` |
| `consensusProofBaseSchema` | `blockNumber` |
| `simulationSchema` | `blockNumber` |
| `simulationWitnessSchema` | `chainId`, `blockNumber` |
| `evidencePackageSchema` | `chainId`, `nonce`, `confirmationsRequired` |
| `safeTransactionListSchema` | `count` |

**2. WebSocket URL redaction (creator.ts)**

The URL redaction regex in `witnessGenerationError` only matched `http://` and `https://`. WebSocket RPC URLs (`wss://node.example.com/api-key`) would leak API keys into the evidence package if witness generation failed.

## Test plan

- [x] All 82 schema/package tests pass (validator, schema-extensions, integration, alignment, creator)
- [x] Full suite: 621 pass (same as before, 8 pre-existing fingerprint failures unrelated)
- [x] Type-check clean (desktop + generator)
- [x] Backward compatible — `.int()` rejects fractional numbers but all legitimate data is already integer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk hardening change: tightens input validation to reject fractional values and broadens error-message URL redaction; main risk is rejecting previously-accepted (but invalid) non-integer payloads.
> 
> **Overview**
> Hardens evidence package creation/validation in two places.
> 
> Updates multiple Zod schemas in `types.ts` to require integer-only values for fields like `chainId`, `nonce`, `blockNumber`, `gasUsed`, `confirmationsRequired`, and list `count` by adding `.int()`.
> 
> Extends the witness generation error redaction in `creator.ts` to also scrub `wss://`/`ws://`-style URLs (in addition to `http(s)`), reducing the chance of leaking RPC API keys in exported diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d811040eafa04dbfd8996174b967845100248dbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->