### PR TITLE
docs: dependency audit, Helios pinning rationale, ethereum_hashing fork rationale

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,137 @@
+# Dependency Audit
+
+Why each dependency exists. Organized by package and split into verification-path (security-critical) vs UI/tooling (non-critical).
+
+## Verification Path (security-critical)
+
+These dependencies are in the trust boundary — they handle crypto, schema validation, or EVM execution.
+
+### packages/core (TypeScript)
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| `viem` | ^2.21 | EIP-712 hashing, ABI decoding, RLP encoding, Merkle Patricia Trie proof verification. Standard Ethereum library with wide adoption and typed APIs. |
+| `zod` | ^4.3 | Schema validation at the trust boundary between evidence packages and the verifier. All package fields are validated before any crypto runs. No network access. |
+
+### apps/desktop/src-tauri (Rust)
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| `helios-consensus-core` | git rev `582fda3` | BLS12-381 sync committee verification for beacon consensus proofs. See [Helios pinning rationale](#helios-pinning-rationale). |
+| `alloy` | 1.0.3 | Ethereum consensus types and SSZ deserialization. Used for parsing beacon block headers and execution payloads. Only `consensus` and `ssz` features enabled. |
+| `revm` | 34 | Local EVM execution for simulation replay. Runs witness world-state through the EVM to verify packaged simulation effects. Only `std` feature enabled, default features disabled. |
+| `tree_hash` | 0.12.1 | SSZ tree hashing for beacon block root computation. |
+| `hex` | 0.4 | Hex encoding/decoding for Ethereum address and hash conversions. |
+| `eyre` | 0.6.8 | Error handling in Rust verification path. |
+| `typenum` | 1 | Compile-time numeric types required by SSZ fixed-length vectors. |
+| `time` | 0.3 | Timestamp parsing for non-beacon envelope freshness checks. Only `parsing` feature enabled. |
+| `serde` / `serde_json` | 1 | JSON serialization for Tauri IPC between the TypeScript frontend and Rust backend. |
+
+### Patched dependencies
+
+| Dependency | Source | Purpose |
+|---|---|---|
+| `ethereum_hashing` | ncitron fork, rev `7ee7094` | See [ethereum_hashing fork rationale](#ethereum_hashing-fork-rationale). |
+
+## UI and Tooling (non-critical)
+
+These dependencies are not in the verification trust boundary. They handle rendering, styling, and build tooling.
+
+### apps/desktop (TypeScript frontend)
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| `react` / `react-dom` | ^18.3 | UI rendering for the desktop verifier frontend. |
+| `@tauri-apps/api` | ^2.0 | Tauri framework frontend API (IPC, window management). |
+| `@tauri-apps/plugin-fs` | ^2.0 | File system access for loading evidence packages. |
+| `@tauri-apps/plugin-dialog` | ^2.0 | Native file picker dialogs. |
+| `viem` | ^2.21 | Address formatting utilities in the UI layer. |
+| `lucide-react` | ^0.454 | Icon library. |
+| `class-variance-authority` | ^0.7 | CSS class composition for component variants. |
+| `clsx` | ^2.1 | Conditional classname joining. |
+| `tailwind-merge` | ^2.5 | Tailwind CSS class conflict resolution. |
+
+### apps/desktop (dev)
+
+| Dependency | Purpose |
+|---|---|
+| `@tauri-apps/cli` | Tauri build toolchain. |
+| `vite` / `@vitejs/plugin-react` | Frontend bundler. |
+| `tailwindcss` / `postcss` | CSS tooling. |
+| `typescript` | Type checking. |
+
+### apps/desktop (Rust, non-verification)
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| `tauri` | 2 | Desktop app framework. `macos-private-api` feature enables native sidebar vibrancy. |
+| `tauri-plugin-fs` / `tauri-plugin-dialog` | 2 | Tauri plugins for file and dialog access. |
+| `tauri-build` | 2 | Build-time code generation for Tauri. |
+| `window-vibrancy` | 0.6 | macOS native vibrancy effect for the sidebar. |
+
+### apps/generator
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| `next` | ^14.2 | React framework. Serves the generator web app. |
+| `react` / `react-dom` | ^18.3 | UI rendering. |
+| `lucide-react` | ^0.454 | Icons. |
+| `class-variance-authority` / `clsx` / `tailwind-merge` | — | CSS utilities (same as desktop). |
+
+### apps/generator (dev)
+
+| Dependency | Purpose |
+|---|---|
+| `tailwindcss` / `postcss` / `autoprefixer` | CSS tooling. |
+| `eslint` / `eslint-config-next` | Linting. |
+| `typescript` | Type checking. |
+
+### packages/core (dev)
+
+| Dependency | Purpose |
+|---|---|
+| `vitest` | Unit test framework. |
+| `typescript` | Type checking. |
+| `@types/node` | Node.js type definitions. |
+
+### packages/cli (dev)
+
+| Dependency | Purpose |
+|---|---|
+| `typescript` | Type checking. |
+| `@types/node` | Node.js type definitions. |
+
+## Helios Pinning Rationale
+
+```toml
+helios-consensus-core = { git = "https://github.com/a16z/helios", rev = "582fda319ed1ecb5fb82c71f4fa755a32e01031a" }
+```
+
+**Why a git rev instead of a tagged release?**
+
+The pinned commit (`582fda3`, 2026-02-18) includes a fix for hex-encoded `blockNumber` and `chainId` fields in beacon API responses ([helios#776](https://github.com/a16z/helios/pull/776)). The latest tagged Helios release is `0.11.0` (2025-12-16), which does not include this fix. SafeLens needs it because beacon finality update responses from some clients return numeric fields as hex strings.
+
+**Commit provenance:** The commit is on the `main` branch of `a16z/helios`, 17 commits ahead of the `0.11.0` tag. It will be included in the next Helios release.
+
+**Action item:** When Helios publishes a release that includes commit `582fda3`, migrate from `rev = "..."` to a version or tag pin.
+
+## ethereum_hashing Fork Rationale
+
+```toml
+[patch.crates-io]
+ethereum_hashing = { git = "https://github.com/ncitron/ethereum_hashing", rev = "7ee70944ed4fabe301551da8c447e4f4ae5e6c35" }
+```
+
+**What the fork changes:** The upstream `ethereum_hashing` crate (by `sigp`) uses the `ring` cryptography library for SHA-256 on x86_64 and falls back to the `sha2` crate on other architectures. The ncitron fork ([commit `7ee7094`](https://github.com/ncitron/ethereum_hashing/commit/7ee70944ed4fabe301551da8c447e4f4ae5e6c35)) removes the `ring` dependency entirely and uses `sha2` unconditionally on all platforms.
+
+**Why this is needed:** `ring` causes cross-compilation issues for non-x86_64 targets (WASM, RISC-V) and adds a heavyweight C dependency. Helios's dependency tree pulls in `ethereum_hashing`, and without this patch, the build requires `ring`'s C compilation toolchain. The `sha2` crate is pure Rust and compiles everywhere.
+
+**Fork author trust:** ncitron is the top contributor to `a16z/helios`. This fork is effectively maintained by the Helios team.
+
+**Upstream status:** The upstream `sigp/ethereum_hashing` added a `sha2` feature flag (post-`v0.8.0`, unreleased) that allows opting into `sha2` without `ring`. However, this is not yet in a tagged release. Once upstream publishes a release with the `sha2` feature, this patch can be replaced with:
+
+```toml
+ethereum_hashing = { version = ">=0.9", default-features = false, features = ["sha2"] }
+```
+
+and the `[patch.crates-io]` section can be removed.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The desktop verifier ships with a CSP that restricts `connect-src` to Tauri IPC 
 
 ## Architecture and runbooks
 
+- Dependency audit: [`DEPENDENCIES.md`](DEPENDENCIES.md)
 - Docs index: [`docs/README.md`](docs/README.md)
 - Interpreter precedence contract: [`docs/architecture/interpretation-precedence.md`](docs/architecture/interpretation-precedence.md)
 - Verification source contract: [`docs/architecture/verification-source-contract.md`](docs/architecture/verification-source-contract.md)

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -15,6 +15,11 @@ tauri-plugin-dialog = "2"
 window-vibrancy = "0.6"
 
 # Helios consensus verification (Phase 4)
+# Pinned to rev 582fda3 (2026-02-18) because it includes a16z/helios#776
+# (hex-encoded blockNumber/chainId in beacon API responses), which is not yet
+# in a tagged release (latest: 0.11.0, 2025-12-16). Migrate to a version/tag
+# pin once Helios publishes a release that includes this commit.
+# See DEPENDENCIES.md for full rationale.
 helios-consensus-core = { git = "https://github.com/a16z/helios", rev = "582fda319ed1ecb5fb82c71f4fa755a32e01031a", package = "helios-consensus-core" }
 alloy = { version = "1.0.3", default-features = false, features = ["consensus", "ssz"] }
 tree_hash = "0.12.1"
@@ -25,6 +30,13 @@ time = { version = "0.3", features = ["parsing"] }
 revm = { version = "34", default-features = false, features = ["std"] }
 
 [patch.crates-io]
+# Fork by ncitron (top Helios contributor) removes the `ring` C dependency and
+# uses the pure-Rust `sha2` crate unconditionally. Required because Helios
+# pulls in ethereum_hashing, and `ring` causes cross-compilation issues.
+# Upstream sigp/ethereum_hashing has an unreleased `sha2` feature flag; once
+# that ships in a tagged release, replace this patch with:
+#   ethereum_hashing = { version = ">=0.9", default-features = false, features = ["sha2"] }
+# See DEPENDENCIES.md for full rationale.
 ethereum_hashing = { git = "https://github.com/ncitron/ethereum_hashing", rev = "7ee70944ed4fabe301551da8c447e4f4ae5e6c35" }
 
 [features]


### PR DESCRIPTION
## Summary

- **#165 – Dependency audit**: New `DEPENDENCIES.md` documenting every direct dependency across all packages, split into verification-path (security-critical: viem, zod, helios, alloy, revm, etc.) and UI/tooling (non-critical: React, Tailwind, Next.js, etc.) with per-dependency justification.
- **#166 – Helios pinning rationale**: Inline Cargo.toml comment explaining why `helios-consensus-core` is pinned to git rev `582fda3` (includes [a16z/helios#776](https://github.com/a16z/helios/pull/776) fix for hex-encoded beacon API fields, not yet in a tagged release past `0.11.0`). Includes action item to migrate to a version pin once a new Helios release ships.
- **#167 – ethereum_hashing fork rationale**: Inline Cargo.toml comment explaining why `ethereum_hashing` uses the ncitron fork (removes `ring` C dependency, uses pure-Rust `sha2` unconditionally). ncitron is the top Helios contributor. Includes action item to drop the patch once upstream releases a version with the `sha2` feature flag.
- **README.md**: Links to `DEPENDENCIES.md` from the architecture section.

## Test plan

- [x] All 634 tests pass (docs-only + comment-only changes)
- [x] Type-check clean
- [ ] CI passes on this PR

Closes #165
Closes #166
Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes plus Cargo.toml comments; no runtime behavior or dependency versions change. Low risk aside from potentially stale documentation if future pins/patches diverge.
> 
> **Overview**
> Adds a new `DEPENDENCIES.md` that documents *why* each direct dependency exists, explicitly separating **verification-path (security-critical)** dependencies from **UI/tooling** ones.
> 
> Updates `README.md` to link to the new dependency audit, and expands `apps/desktop/src-tauri/Cargo.toml` with rationale comments for the `helios-consensus-core` git rev pin and the `ethereum_hashing` fork/patch (including guidance to migrate back to tagged upstream releases when available).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b4142171f7cdf85bb905fb7929d6b181ad6be51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->